### PR TITLE
mcp: fix status() to not overwrite connected with failed

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -161,6 +161,7 @@ export namespace MCP {
         }
         if (state.clients[key]) {
           result[key] = "connected"
+          continue
         }
         result[key] = "failed"
       }


### PR DESCRIPTION
Fix MCP status showing servers as failed when connected

Summary
- Correct `MCP.status()` logic to avoid overwriting a `connected` status with `failed`.
- This resolves the UI showing `gh_grep` and `chrome-devtools` as `failed` despite being usable.

Details
- Previous logic set `result[key] = "connected"` when the client existed, but then immediately set `result[key] = "failed"` unconditionally. Added a `continue` to preserve `connected`.
- Keeps the existing response shape: `Record<string, "connected" | "failed" | "disabled">`, matching opencode-web's current expectations.
- Note: sst/opencode's `opentui` branch returns `{ name: { status } }`. If/when we adopt that shape, we'll align the web client accordingly. For now, this PR fixes correctness without changing the API shape.

Verification
- In opencode-web, `/mcp` drives the `McpStatus` component. After this change, servers with active clients report `connected` and render green.

Upstream
- The `opentui` branch appears to have addressed this; this fork PR ensures we are unblocked now while upstream changes land.
