### PR TITLE
Serve static files if available instead of proxying

### DIFF
--- a/packages/opencode/.gitignore
+++ b/packages/opencode/.gitignore
@@ -2,3 +2,4 @@ research
 dist
 gen
 app.log
+static

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -1,6 +1,7 @@
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import path from "path"
+import fs from "fs"
 import { $ } from "bun"
 import z from "zod"
 import { NamedError } from "@opencode-ai/util/error"
@@ -60,6 +61,11 @@ export namespace Installation {
 
   export function isLocal() {
     return CHANNEL === "local"
+  }
+
+  export function isBundled() {
+    const staticPath = path.join(path.dirname(process.execPath), "static")
+    return fs.existsSync(staticPath)
   }
 
   export async function method() {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -45,10 +45,12 @@ import { TuiEvent } from "@/cli/cmd/tui/event"
 import { Snapshot } from "@/snapshot"
 import { SessionSummary } from "@/session/summary"
 import { SessionStatus } from "@/session/status"
-import { upgradeWebSocket, websocket } from "hono/bun"
+import { upgradeWebSocket, websocket, serveStatic } from "hono/bun"
 import { errors } from "./error"
 import { Pty } from "@/pty"
 import { Installation } from "@/installation"
+import fs from "fs"
+import path from "path"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -2580,6 +2582,14 @@ export namespace Server {
         },
       )
       .all("/*", async (c) => {
+        if (Installation.isBundled()) {
+          const res = await serveStatic({
+            root: path.relative(process.cwd(), path.join(path.dirname(process.execPath), "static")),
+            rewriteRequestPath: (path) => (path === "/" ? "/index.html" : path),
+          })(c, async () => {})
+          if (res) return res
+        }
+
         const desktopHost = Installation.isLocal()
           ? process.env.OPENCODE_DESKTOP_URL || "http://localhost:3000"
           : process.env.SHUVCODE_DESKTOP_URL || "https://desktop.shuv.ai"


### PR DESCRIPTION
Allows an easier time setting up a "contained" install (meaning both the desktop/ web files and backend) which is quite non-intuitive right now unless I'm missing something