### PR TITLE
Properly handle SIGTERM and SIGINT

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -25,7 +25,16 @@ export const ServeCommand = cmd({
       hostname,
     })
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
+
+    const stop = async () => {
+      console.log("stopping server...")
+      await server.stop()
+      process.exit(0)
+    }
+
+    process.on("SIGTERM", stop)
+    process.on("SIGINT", stop)
+
     await new Promise(() => {})
-    await server.stop()
   },
 })


### PR DESCRIPTION
Fixes issue where killing the server when deployed doesn't work too well