### PR TITLE
fix: update Dockerfile to use renamed shuvcode binary

### DIFF
--- a/packages/opencode/Dockerfile
+++ b/packages/opencode/Dockerfile
@@ -7,12 +7,12 @@ ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
 RUN apk add libgcc libstdc++ ripgrep
 
 FROM base AS build-amd64
-COPY dist/opencode-linux-x64-baseline-musl/bin/opencode /usr/local/bin/opencode
+COPY dist/shuvcode-linux-x64-baseline-musl/bin/shuvcode /usr/local/bin/shuvcode
 
 FROM base AS build-arm64
-COPY dist/opencode-linux-arm64-musl/bin/opencode /usr/local/bin/opencode
+COPY dist/shuvcode-linux-arm64-musl/bin/shuvcode /usr/local/bin/shuvcode
 
 ARG TARGETARCH
 FROM build-${TARGETARCH}
-RUN opencode --version
-ENTRYPOINT ["opencode"]
+RUN shuvcode --version
+ENTRYPOINT ["shuvcode"]


### PR DESCRIPTION
Updates the Dockerfile to use the renamed shuvcode binary and corresponding build artifacts introduced in the rebranding.