### PR TITLE
fix(docker): add git to container image

### DIFF
--- a/packages/opencode/Dockerfile
+++ b/packages/opencode/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine AS base
 # On ephemeral containers, the cache is not useful
 ARG BUN_RUNTIME_TRANSPILER_CACHE_PATH=0
 ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
-RUN apk add libgcc libstdc++ ripgrep
+RUN apk add libgcc libstdc++ ripgrep git
 
 FROM base AS build-amd64
 COPY dist/shuvcode-linux-x64-baseline-musl/bin/shuvcode /usr/local/bin/shuvcode


### PR DESCRIPTION
## Summary
- Add git to the Docker image dependencies

Git is required for project creation and initialization. Without it, creating new projects fails with exit code 1 when trying to run `git init`.

## Error
```
ShellError: Failed with exit code 1
    at new ShellPromise (native:75:16)
    at BunShell (native:191:35)
    at <anonymous> (src/project/project.ts:269:15)
```