### PR TITLE
Improve mobile Web UI experience

### DIFF
--- a/packages/desktop/src/components/terminal.tsx
+++ b/packages/desktop/src/components/terminal.tsx
@@ -241,7 +241,7 @@ export const Terminal = (props: TerminalProps) => {
       data-prevent-autofocus
       classList={{
         ...(local.classList ?? {}),
-        "size-full px-6 py-3 font-mono": true,
+        "size-full px-3 sm:px-6 py-3 font-mono": true,
         [local.class ?? ""]: !!local.class,
       }}
       {...others}

--- a/packages/desktop/src/context/layout.tsx
+++ b/packages/desktop/src/context/layout.tsx
@@ -77,10 +77,17 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         filesCount?: number
         onOpen?: () => void
       }
+      mobileMessageNav: {
+        visible?: boolean
+        messages?: { id: string; title?: string }[]
+        currentIndex?: number
+        onSelect?: (index: number) => void
+      }
     }>({
       connect: {},
       dialog: {},
       mobileReview: {},
+      mobileMessageNav: {},
     })
     const usedColors = new Set<AvatarColorKey>()
 
@@ -278,6 +285,21 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         },
         unregister() {
           setEphemeral("mobileReview", { visible: false, filesCount: 0, onOpen: undefined })
+        },
+      },
+      mobileMessageNav: {
+        visible: createMemo(() => ephemeral.mobileMessageNav?.visible ?? false),
+        messages: createMemo(() => ephemeral.mobileMessageNav?.messages ?? []),
+        currentIndex: createMemo(() => ephemeral.mobileMessageNav?.currentIndex ?? 0),
+        onSelect: createMemo(() => ephemeral.mobileMessageNav?.onSelect),
+        register(messages: { id: string; title?: string }[], currentIndex: number, onSelect: (index: number) => void) {
+          setEphemeral("mobileMessageNav", { visible: true, messages, currentIndex, onSelect })
+        },
+        update(currentIndex: number) {
+          setEphemeral("mobileMessageNav", "currentIndex", currentIndex)
+        },
+        unregister() {
+          setEphemeral("mobileMessageNav", { visible: false, messages: [], currentIndex: 0, onSelect: undefined })
         },
       },
       theme: {

--- a/packages/desktop/src/pages/layout.tsx
+++ b/packages/desktop/src/pages/layout.tsx
@@ -857,7 +857,7 @@ export default function Layout(props: ParentProps) {
                 <FontPicker />
                 <ThemePicker />
               </div>
-              <div class="hidden sm:flex items-center gap-4">
+              <div class="flex items-center gap-4">
                 <Tooltip
                   class="shrink-0"
                   value={

--- a/packages/desktop/src/pages/layout.tsx
+++ b/packages/desktop/src/pages/layout.tsx
@@ -723,7 +723,7 @@ export default function Layout(props: ParentProps) {
               }
             >
               <div class="flex items-center gap-3 min-w-0 grow flex-nowrap">
-                <div class="flex items-center gap-2 min-w-0">
+                <div class="hidden sm:flex items-center gap-2 min-w-0">
                   <Select
                     options={layout.projects.list().map((project) => project.worktree)}
                     current={currentDirectory()}
@@ -742,7 +742,7 @@ export default function Layout(props: ParentProps) {
                       </div>
                     )}
                   </Select>
-                  <div class="text-text-weaker hidden sm:block">/</div>
+                  <div class="text-text-weaker">/</div>
                 </div>
                 <div class="flex items-center min-w-0 sm:hidden">
                   <DropdownMenu>

--- a/packages/desktop/src/pages/layout.tsx
+++ b/packages/desktop/src/pages/layout.tsx
@@ -857,7 +857,44 @@ export default function Layout(props: ParentProps) {
                 <FontPicker />
                 <ThemePicker />
               </div>
-              <div class="flex items-center gap-4">
+              <div class="flex items-center gap-2">
+                {/* Mobile message navigation */}
+                <Show when={layout.mobileMessageNav.visible()}>
+                  <div class="sm:hidden">
+                    <DropdownMenu>
+                      <DropdownMenu.Trigger
+                        as={Button}
+                        variant="ghost"
+                        size="small"
+                        class="gap-1 px-2"
+                      >
+                        <span class="text-12-medium">
+                          {layout.mobileMessageNav.currentIndex() + 1}/{layout.mobileMessageNav.messages().length}
+                        </span>
+                        <Icon name="chevron-down" size="small" />
+                      </DropdownMenu.Trigger>
+                      <DropdownMenu.Portal>
+                        <DropdownMenu.Content class="max-w-[calc(100vw-2rem)] max-h-80 overflow-y-auto">
+                          <For each={layout.mobileMessageNav.messages()}>
+                            {(msg, index) => (
+                              <DropdownMenu.Item onSelect={() => layout.mobileMessageNav.onSelect()?.(index())}>
+                                <DropdownMenu.ItemLabel class="flex items-center gap-3">
+                                  <span class="text-text-weak shrink-0">{index() + 1}</span>
+                                  <span class="truncate">{msg.title || "Message"}</span>
+                                </DropdownMenu.ItemLabel>
+                                <Show when={index() === layout.mobileMessageNav.currentIndex()}>
+                                  <DropdownMenu.ItemIndicator>
+                                    <Icon name="check-small" size="small" />
+                                  </DropdownMenu.ItemIndicator>
+                                </Show>
+                              </DropdownMenu.Item>
+                            )}
+                          </For>
+                        </DropdownMenu.Content>
+                      </DropdownMenu.Portal>
+                    </DropdownMenu>
+                  </div>
+                </Show>
                 <Tooltip
                   class="shrink-0"
                   value={

--- a/packages/desktop/src/pages/session.tsx
+++ b/packages/desktop/src/pages/session.tsx
@@ -153,6 +153,25 @@ export default function Page() {
     layout.mobileReview.unregister()
   })
 
+  // Register mobile message navigation in header when there are multiple messages
+  createEffect(() => {
+    const messages = visibleUserMessages()
+    if (messages.length > 1) {
+      const currentIndex = messages.findIndex((m) => m.id === activeMessage()?.id)
+      layout.mobileMessageNav.register(
+        messages.map((m) => ({ id: m.id, title: m.summary?.title })),
+        currentIndex >= 0 ? currentIndex : 0,
+        (index) => setActiveMessage(messages[index])
+      )
+    } else {
+      layout.mobileMessageNav.unregister()
+    }
+  })
+
+  onCleanup(() => {
+    layout.mobileMessageNav.unregister()
+  })
+
   createEffect(() => {
     if (layout.terminal.opened()) {
       if (terminal.all().length === 0) {

--- a/packages/desktop/src/pages/session.tsx
+++ b/packages/desktop/src/pages/session.tsx
@@ -128,6 +128,7 @@ export default function Page() {
     userInteracted: false,
     stepsExpanded: true,
     mobileTabsOpen: false,
+    mobileTerminalFullscreen: false,
     diffSplit: false,
   })
   let inputRef!: HTMLDivElement
@@ -890,6 +891,17 @@ export default function Page() {
                   </Tooltip>
                 </div>
               </Tabs.List>
+              {/* Mobile fullscreen button - positioned absolutely */}
+              <div class="sm:hidden absolute top-1 right-2 z-10">
+                <Tooltip value="Fullscreen" class="flex items-center">
+                  <IconButton
+                    icon="expand"
+                    variant="ghost"
+                    iconSize="small"
+                    onClick={() => setStore("mobileTerminalFullscreen", true)}
+                  />
+                </Tooltip>
+              </div>
               <For each={terminal.all()}>
                 {(pty) => (
                   <Tabs.Content value={pty.id}>
@@ -1078,6 +1090,67 @@ export default function Page() {
                       </Tabs.Content>
                     )
                   }}
+                </For>
+              </Tabs>
+            </div>
+          </div>
+        </Show>
+
+        {/* Mobile terminal fullscreen overlay */}
+        <Show when={store.mobileTerminalFullscreen}>
+          <div
+            class="fixed inset-0 z-50 sm:hidden flex flex-col bg-background-base"
+            style={{
+              "padding-top": "var(--safe-area-inset-top)",
+              "padding-bottom": "var(--safe-area-inset-bottom)",
+              "padding-left": "var(--safe-area-inset-left)",
+              "padding-right": "var(--safe-area-inset-right)",
+            }}
+          >
+            {/* Mobile terminal header */}
+            <div class="h-12 shrink-0 border-b border-border-weak-base flex items-center justify-between px-4">
+              <div class="flex items-center gap-3">
+                <Icon name="layout-bottom" size="small" />
+                <span class="text-14-medium text-text-strong">Terminal</span>
+              </div>
+              <IconButton
+                icon="close"
+                variant="ghost"
+                iconSize="large"
+                onClick={() => setStore("mobileTerminalFullscreen", false)}
+                aria-label="Close"
+              />
+            </div>
+
+            {/* Mobile terminal content */}
+            <div class="flex-1 min-h-0 overflow-hidden">
+              <Tabs variant="alt" value={terminal.active()} onChange={terminal.open}>
+                <div class="shrink-0 flex border-b border-border-weak-base overflow-x-auto">
+                  <Tabs.List>
+                    <For each={terminal.all()}>
+                      {(pty) => (
+                        <Tabs.Trigger value={pty.id} class="max-w-40 truncate">
+                          {pty.title}
+                        </Tabs.Trigger>
+                      )}
+                    </For>
+                  </Tabs.List>
+                  <div class="flex items-center justify-center px-2">
+                    <IconButton
+                      icon="plus-small"
+                      variant="ghost"
+                      iconSize="large"
+                      onClick={terminal.new}
+                      aria-label="New terminal"
+                    />
+                  </div>
+                </div>
+                <For each={terminal.all()}>
+                  {(pty) => (
+                    <Tabs.Content value={pty.id} class="h-full">
+                      <Terminal pty={pty} onCleanup={terminal.update} onConnectError={() => terminal.clone(pty.id)} />
+                    </Tabs.Content>
+                  )}
                 </For>
               </Tabs>
             </div>

--- a/packages/desktop/src/pages/session.tsx
+++ b/packages/desktop/src/pages/session.tsx
@@ -873,34 +873,35 @@ export default function Page() {
             <DragDropSensors />
             <ConstrainDragYAxis />
             <Tabs variant="alt" value={terminal.active()} onChange={terminal.open}>
-              <Tabs.List class="h-10">
-                <SortableProvider ids={terminal.all().map((t: LocalPTY) => t.id)}>
-                  <For each={terminal.all()}>{(pty) => <SortableTerminalTab terminal={pty} />}</For>
-                </SortableProvider>
-                <div class="h-full flex items-center justify-center">
-                  <Tooltip
-                    value={
-                      <div class="flex items-center gap-2">
-                        <span>New terminal</span>
-                        <span class="text-icon-base text-12-medium">{command.keybind("terminal.new")}</span>
-                      </div>
-                    }
-                    class="flex items-center"
-                  >
-                    <IconButton icon="plus-small" variant="ghost" iconSize="large" onClick={terminal.new} />
+              <div class="flex h-10">
+                <Tabs.List class="h-10 flex-1 min-w-0 overflow-x-auto">
+                  <SortableProvider ids={terminal.all().map((t: LocalPTY) => t.id)}>
+                    <For each={terminal.all()}>{(pty) => <SortableTerminalTab terminal={pty} />}</For>
+                  </SortableProvider>
+                  <div class="h-full flex items-center justify-center">
+                    <Tooltip
+                      value={
+                        <div class="flex items-center gap-2">
+                          <span>New terminal</span>
+                          <span class="text-icon-base text-12-medium">{command.keybind("terminal.new")}</span>
+                        </div>
+                      }
+                      class="flex items-center"
+                    >
+                      <IconButton icon="plus-small" variant="ghost" iconSize="large" onClick={terminal.new} />
+                    </Tooltip>
+                  </div>
+                </Tabs.List>
+                <div class="sm:hidden h-full flex items-center justify-center shrink-0 px-2 border-l border-border-weak-base">
+                  <Tooltip value="Fullscreen terminal" class="flex items-center">
+                    <IconButton
+                      icon="expand"
+                      variant="ghost"
+                      iconSize="small"
+                      onClick={() => setStore("mobileTerminalFullscreen", true)}
+                    />
                   </Tooltip>
                 </div>
-              </Tabs.List>
-              {/* Mobile fullscreen button - positioned absolutely */}
-              <div class="sm:hidden absolute top-1 right-2 z-10">
-                <Tooltip value="Fullscreen" class="flex items-center">
-                  <IconButton
-                    icon="expand"
-                    variant="ghost"
-                    iconSize="small"
-                    onClick={() => setStore("mobileTerminalFullscreen", true)}
-                  />
-                </Tooltip>
               </div>
               <For each={terminal.all()}>
                 {(pty) => (
@@ -1107,26 +1108,10 @@ export default function Page() {
               "padding-right": "var(--safe-area-inset-right)",
             }}
           >
-            {/* Mobile terminal header */}
-            <div class="h-12 shrink-0 border-b border-border-weak-base flex items-center justify-between px-4">
-              <div class="flex items-center gap-3">
-                <Icon name="layout-bottom" size="small" />
-                <span class="text-14-medium text-text-strong">Terminal</span>
-              </div>
-              <IconButton
-                icon="close"
-                variant="ghost"
-                iconSize="large"
-                onClick={() => setStore("mobileTerminalFullscreen", false)}
-                aria-label="Close"
-              />
-            </div>
-
-            {/* Mobile terminal content */}
-            <div class="flex-1 min-h-0 overflow-hidden">
-              <Tabs variant="alt" value={terminal.active()} onChange={terminal.open}>
-                <div class="shrink-0 flex border-b border-border-weak-base overflow-x-auto">
-                  <Tabs.List>
+            <div class="flex-1 min-h-0 overflow-hidden flex flex-col">
+              <Tabs variant="alt" value={terminal.active()} onChange={terminal.open} class="flex flex-col h-full">
+                <div class="shrink-0 flex h-10">
+                  <Tabs.List class="flex-1 min-w-0 overflow-x-auto">
                     <For each={terminal.all()}>
                       {(pty) => (
                         <Tabs.Trigger value={pty.id} class="max-w-40 truncate">
@@ -1134,20 +1119,31 @@ export default function Page() {
                         </Tabs.Trigger>
                       )}
                     </For>
+                    <div class="h-full flex items-center justify-center">
+                      <IconButton
+                        icon="plus-small"
+                        variant="ghost"
+                        iconSize="large"
+                        onClick={terminal.new}
+                        aria-label="New terminal"
+                      />
+                    </div>
                   </Tabs.List>
-                  <div class="flex items-center justify-center px-2">
-                    <IconButton
-                      icon="plus-small"
-                      variant="ghost"
-                      iconSize="large"
-                      onClick={terminal.new}
-                      aria-label="New terminal"
-                    />
+                  <div class="h-full flex items-center justify-center shrink-0 px-2 border-l border-border-weak-base">
+                    <Tooltip value="Exit fullscreen" class="flex items-center">
+                      <IconButton
+                        icon="collapse"
+                        variant="ghost"
+                        iconSize="small"
+                        onClick={() => setStore("mobileTerminalFullscreen", false)}
+                        aria-label="Exit fullscreen"
+                      />
+                    </Tooltip>
                   </div>
                 </div>
                 <For each={terminal.all()}>
                   {(pty) => (
-                    <Tabs.Content value={pty.id} class="h-full">
+                    <Tabs.Content value={pty.id} class="flex-1 min-h-0">
                       <Terminal pty={pty} onCleanup={terminal.update} onConnectError={() => terminal.clone(pty.id)} />
                     </Tabs.Content>
                   )}

--- a/packages/ui/src/components/session-message-rail.css
+++ b/packages/ui/src/components/session-message-rail.css
@@ -1,5 +1,4 @@
 [data-component="session-message-rail"] {
-  display: flex;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Summary
- Fix message rail visibility on mobile (CSS specificity issue)
- Show terminal toggle button on mobile
- Hide project selection from top bar on mobile (available in menu)
- Add fullscreen terminal mode for mobile with expand/collapse button
- Add mobile message navigation dropdown in header (shows "2/5" style navigation)

## Test plan
- [x] Test on mobile viewport or device
- [x] Verify message rail is hidden on mobile
- [x] Verify terminal icon is visible and works on mobile
- [x] Verify fullscreen terminal can be opened and closed
- [x] Verify message navigation dropdown appears with multiple messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)