### PR TITLE
Add /tools command to list available tools

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -12,6 +12,7 @@ import { SyncProvider, useSync } from "@tui/context/sync"
 import { LocalProvider, useLocal } from "@tui/context/local"
 import { DialogModel, useConnected } from "@tui/component/dialog-model"
 import { DialogMcp } from "@tui/component/dialog-mcp"
+import { DialogTools } from "@tui/component/dialog-tools"
 import { DialogIde } from "@tui/component/dialog-ide"
 import { DialogStatus } from "@tui/component/dialog-status"
 import { DialogThemeList } from "@tui/component/dialog-theme-list"
@@ -348,6 +349,14 @@ function App() {
       category: "Agent",
       onSelect: () => {
         dialog.replace(() => <DialogMcp />)
+      },
+    },
+    {
+      title: "List tools",
+      value: "tool.list",
+      category: "Agent",
+      onSelect: () => {
+        dialog.replace(() => <DialogTools />)
       },
     },
     {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-tools.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-tools.tsx
@@ -1,0 +1,44 @@
+import { createMemo, createResource } from "solid-js"
+import { map, pipe, sortBy } from "remeda"
+import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
+import { useSDK } from "@tui/context/sdk"
+
+type ToolInfo = {
+  id: string
+  enabled: boolean
+}
+
+export function DialogTools() {
+  const sdk = useSDK()
+
+  const [tools] = createResource(async () => {
+    const response = await fetch(`${sdk.url}/tool/list`)
+    if (!response.ok) return []
+    return (await response.json()) as ToolInfo[]
+  })
+
+  const options = createMemo((): DialogSelectOption<string>[] => {
+    const toolList = tools() ?? []
+
+    return pipe(
+      toolList,
+      sortBy((t) => t.id),
+      map((t) => ({
+        value: t.id,
+        title: t.id,
+        footer: t.enabled ? undefined : "disabled",
+        category: undefined,
+      })),
+    )
+  })
+
+  return (
+    <DialogSelect
+      title="Tools"
+      options={options()}
+      onSelect={() => {
+        // Don't close on select, only on escape
+      }}
+    />
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -357,6 +357,11 @@ export function Autocomplete(props: {
         onSelect: () => command.trigger("mcp.list"),
       },
       {
+        display: "/tools",
+        description: "list tools",
+        onSelect: () => command.trigger("tool.list"),
+      },
+      {
         display: "/ide",
         description: "toggle IDEs",
         onSelect: () => command.trigger("ide.list"),

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -10,7 +10,7 @@ import { proxy } from "hono/proxy"
 import { Session } from "../session"
 import z from "zod"
 import { Provider } from "../provider/provider"
-import { filter, mapValues, sortBy, pipe } from "remeda"
+import { filter, mapValues, sortBy, pipe, mergeDeep } from "remeda"
 import { NamedError } from "@opencode-ai/util/error"
 import { ModelsDev } from "../provider/models"
 import { Ripgrep } from "../file/ripgrep"
@@ -43,6 +43,7 @@ import { Ide } from "../ide"
 import { Storage } from "../storage/storage"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
 import { TuiEvent } from "@/cli/cmd/tui/event"
+import { Wildcard } from "@/util/wildcard"
 import { Snapshot } from "@/snapshot"
 import { SessionSummary } from "@/session/summary"
 import { SessionStatus } from "@/session/status"
@@ -451,6 +452,52 @@ export namespace Server {
           const config = c.req.valid("json")
           await Config.update(config)
           return c.json(config)
+        },
+      )
+      .get(
+        "/tool/list",
+        describeRoute({
+          summary: "List tools",
+          description: "Get a list of all available tools with their enabled status.",
+          operationId: "tool.list",
+          responses: {
+            200: {
+              description: "Tool list",
+              content: {
+                "application/json": {
+                  schema: resolver(
+                    z.array(
+                      z.object({
+                        id: z.string(),
+                        enabled: z.boolean(),
+                      }),
+                    ),
+                  ),
+                },
+              },
+            },
+          },
+        }),
+        async (c) => {
+          const builtinIds = await ToolRegistry.ids()
+          const mcpTools = await MCP.tools()
+          const mcpIds = Object.keys(mcpTools)
+          // Combine and filter out 'invalid' tool
+          const allIds = [...builtinIds.filter((id) => id !== "invalid"), ...mcpIds]
+
+          // Get enabled status based on agent tools config
+          const defaultAgentName = await Agent.defaultAgent()
+          const agent = await Agent.get(defaultAgentName)
+          const enabledTools = agent
+            ? mergeDeep(agent.tools, await ToolRegistry.enabled(agent))
+            : ({} as Record<string, boolean>)
+
+          return c.json(
+            allIds.map((id) => ({
+              id,
+              enabled: Wildcard.all(id, enabledTools) !== false,
+            })),
+          )
         },
       )
       .get(


### PR DESCRIPTION
## Summary
- Add `/tools` slash command that displays all available tools (builtin + MCP) with their enabled/disabled status based on the agent's tools configuration