### PR TITLE
feat(app): image preview in file tabs

### DIFF
--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -395,8 +395,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       }
 
       const list = async (path: string) => {
+        const listPath = path ? path + "/" : ""
         return sdk.client.file
-          .list({ path: path + "/" })
+          .list({ path: listPath })
           .then((x) => {
             setStore(
               "node",

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -364,9 +364,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const fetch = async (path: string) => {
         const relativePath = relative(path)
         const parent = relativePath.split("/").slice(0, -1).join("/")
-        if (parent) {
-          await list(parent)
-        }
+        await list(parent)
       }
 
       const init = async (path: string) => {

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -942,8 +942,6 @@ export default function Page() {
                 <For each={tabs().all()}>
                   {(tab) => {
                     const path = tab.startsWith("file://") ? tab.replace("file://", "") : undefined
-                    // Trigger the file load
-                    if (path) local.file.init(path)
                     return (
                       <Tabs.Content value={tab} class="mt-3">
                         <Show when={path}>

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -8,6 +8,7 @@ import {
   createResource,
   createMemo,
   createEffect,
+  createSignal,
   on,
   createRenderEffect,
   batch,
@@ -20,6 +21,7 @@ import { PromptInput } from "@/components/prompt-input"
 import { DateTime } from "luxon"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
+import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { DiffChanges } from "@opencode-ai/ui/diff-changes"
@@ -579,6 +581,71 @@ export default function Page() {
     )
   }
 
+  const FileTabContent = (props: { path: string; codeComponent: typeof codeComponent }): JSX.Element => {
+    const [file] = createResource(
+      () => props.path,
+      async (path) => local.file.node(path),
+    )
+    const content = createMemo(() => file()?.content)
+    const isImage = createMemo(
+      () => content()?.encoding === "base64" && content()?.mimeType?.startsWith("image/"),
+    )
+    const isSvg = createMemo(() => content()?.mimeType === "image/svg+xml")
+    const [showCode, setShowCode] = createSignal(false)
+    const decodedContent = createMemo(() => {
+      const c = content()
+      if (c?.encoding === "base64" && c.content) {
+        return atob(c.content)
+      }
+      return c?.content ?? ""
+    })
+    return (
+      <Switch>
+        <Match when={isImage() && !showCode() && file()}>
+          {(f) => (
+            <div class="flex flex-col h-full">
+              <Show when={isSvg()}>
+                <div class="flex justify-end p-2 border-b border-border-base">
+                  <Button size="small" icon="code" onClick={() => setShowCode(true)}>
+                    View code
+                  </Button>
+                </div>
+              </Show>
+              <div class="flex items-center justify-center flex-1 p-4">
+                <img
+                  src={`data:${f().content!.mimeType};base64,${f().content!.content}`}
+                  alt={f().path}
+                  class="max-w-full max-h-[80vh] object-contain"
+                />
+              </div>
+            </div>
+          )}
+        </Match>
+        <Match when={content()?.content != null}>
+          <div class="flex flex-col h-full">
+            <Show when={isSvg()}>
+              <div class="flex justify-end p-2 border-b border-border-base">
+                <Button size="small" icon="photo" onClick={() => setShowCode(false)}>
+                  View image
+                </Button>
+              </div>
+            </Show>
+            <Dynamic
+              component={props.codeComponent}
+              file={{
+                name: file()?.path ?? props.path,
+                contents: decodedContent(),
+                cacheKey: checksum(decodedContent()),
+              }}
+              overflow="scroll"
+              class="select-text pb-40"
+            />
+          </div>
+        </Match>
+      </Switch>
+    )
+  }
+
   const SortableTab = (props: {
     tab: string
     onTabClick: (tab: string) => void
@@ -874,33 +941,14 @@ export default function Page() {
                 </Show>
                 <For each={tabs().all()}>
                   {(tab) => {
-                    const [file] = createResource(
-                      () => tab,
-                      async (tab) => {
-                        if (tab.startsWith("file://")) {
-                          return local.file.node(tab.replace("file://", ""))
-                        }
-                        return undefined
-                      },
-                    )
+                    const path = tab.startsWith("file://") ? tab.replace("file://", "") : undefined
+                    // Trigger the file load
+                    if (path) local.file.init(path)
                     return (
                       <Tabs.Content value={tab} class="mt-3">
-                        <Switch>
-                          <Match when={file()}>
-                            {(f) => (
-                              <Dynamic
-                                component={codeComponent}
-                                file={{
-                                  name: f().path,
-                                  contents: f().content?.content ?? "",
-                                  cacheKey: checksum(f().content?.content ?? ""),
-                                }}
-                                overflow="scroll"
-                                class="select-text pb-40"
-                              />
-                            )}
-                          </Match>
-                        </Switch>
+                        <Show when={path}>
+                          <FileTabContent path={path!} codeComponent={codeComponent} />
+                        </Show>
                       </Tabs.Content>
                     )
                   }}


### PR DESCRIPTION
## Summary

- Always call `list()` for parent directory in file fetch (removes unnecessary conditional)
- Add image preview support in file tabs
- SVG files get a toggle to switch between rendered image and source code

## Changes

- `packages/app/src/context/local.tsx`: Remove conditional check before `list(parent)`
- `packages/app/src/pages/session.tsx`: New `FileTabContent` component for rendering images and code with SVG toggle

## Proof

Before: 

https://github.com/user-attachments/assets/89f3ac56-2960-4450-81cf-ac8b24e2c0de

After:


https://github.com/user-attachments/assets/302b7b48-4856-4673-8b77-c97bc972873c

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>


Added image preview functionality to file tabs with special handling for SVG files. Users can now view images directly in tabs, and SVG files get a toggle to switch between rendered preview and source code view.

- **Image Preview**: New `FileTabContent` component detects base64-encoded images by mimeType and renders them with proper styling
- **SVG Toggle**: SVG files can be viewed as both rendered images and source code with toggle buttons
- **File Loading**: Simplified parent directory listing by removing conditional check - now always calls `list(parent)` regardless of parent path
- **Code Refactor**: Moved from inline file loading logic to dedicated `FileTabContent` component for better separation of concerns

Minor optimization opportunity: redundant `local.file.init()` call on line 946 since `FileTabContent` already handles initialization through `local.file.node()`.


</details>
<details open><summary><h3>Confidence Score: 4/5</h3></summary>


- This PR is safe to merge with minimal risk
- Clean feature addition with well-structured code following SolidJS patterns. The changes are isolated and straightforward - image detection via mimeType, proper reactive patterns with createMemo and createSignal, and appropriate component structure. Minor optimization opportunity with redundant init() call and potential edge case with empty parent path in list(), but neither should cause functional issues.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/app/src/context/local.tsx | Removed conditional check before calling `list(parent)` - now always calls even when parent is empty string |
| packages/app/src/pages/session.tsx | Added `FileTabContent` component with image preview and SVG toggle functionality, refactored tab content rendering |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant FileTabContent
    participant LocalContext
    participant SDK

    User->>FileTabContent: Opens file tab
    FileTabContent->>LocalContext: createResource(() => local.file.node(path))
    LocalContext->>LocalContext: init(path)
    LocalContext->>LocalContext: fetch(path)
    LocalContext->>LocalContext: Calculate parent directory
    LocalContext->>SDK: list(parent + "/")
    SDK-->>LocalContext: Return parent directory contents
    LocalContext->>SDK: read file content
    SDK-->>LocalContext: Return file with content & mimeType
    LocalContext-->>FileTabContent: Return file node

    alt Image file (base64 encoded)
        alt SVG file
            FileTabContent->>User: Show image with "View code" toggle
            User->>FileTabContent: Click "View code"
            FileTabContent->>FileTabContent: setShowCode(true)
            FileTabContent->>User: Show decoded SVG source with "View image" toggle
        else Non-SVG image
            FileTabContent->>User: Show image preview
        end
    else Text file
        FileTabContent->>User: Show code editor
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->