### PR TITLE
fix(app): handle empty path in file list to avoid leading slash

### DIFF
--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -436,8 +436,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       }
 
       const list = async (path: string) => {
+        const listPath = path ? path + "/" : ""
         return sdk.client.file
-          .list({ path: path + "/" })
+          .list({ path: listPath })
           .then((x) => {
             setStore(
               "node",


### PR DESCRIPTION
## Summary
- Fix file list API call to handle empty/root path correctly, avoiding leading slash in path
- Always call list for parent directory in file fetch, even when parent is empty string (root)

These changes ensure proper file listing at the project root level.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>


Fixed file listing at project root by handling empty path correctly. The changes ensure that when listing files in the root directory, an empty string is passed to the API instead of a leading slash (`"/"`), and the `fetch` function always calls `list` for the parent directory, even when the parent is the root (empty string).

**Key changes:**
- Modified `list` function to conditionally add trailing slash: uses empty string for root, adds `"/"` suffix for non-empty paths
- Removed conditional check in `fetch` function that prevented listing root directory when parent was empty
- Prevents malformed paths like `"/"` from being sent to the file listing API

The fix aligns with the backend `File.list` implementation which expects an optional directory parameter that can be empty for root listings.


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The changes are minimal, focused, and correctly address a specific path-handling bug. The fix properly handles the edge case of empty/root paths by conditionally formatting the path parameter. The logic aligns with the backend File.list implementation which accepts an optional dir parameter. No security issues, breaking changes, or unintended side effects identified.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/app/src/context/local.tsx | Fixed root directory file listing by handling empty path correctly (avoiding leading slash) and removing unnecessary parent check in fetch function |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant FileContext as File Context
    participant SDK as SDK Client
    participant Server as File Server

    Note over User,Server: Scenario: Fetching a file at root level

    User->>FileContext: fetch(path)
    FileContext->>FileContext: relativePath = relative(path)
    FileContext->>FileContext: parent = relativePath.split("/").slice(0, -1).join("/")
    Note over FileContext: parent is empty string "" for root files
    FileContext->>FileContext: list(parent)
    
    alt Before Fix: parent was ""
        FileContext->>FileContext: Check if (parent) - FALSE
        Note over FileContext: list() not called, directory not loaded!
    else After Fix: parent is ""
        FileContext->>SDK: file.list({ path: "" })
        Note over SDK: listPath = "" ? "" + "/" : "" = ""
        SDK->>Server: GET /file?path=""
        Server->>SDK: Returns root directory contents
        SDK->>FileContext: Update store with file nodes
    end

    Note over User,Server: Scenario: Listing root directory

    User->>FileContext: list("")
    
    alt Before Fix
        FileContext->>SDK: file.list({ path: "" + "/" })
        Note over SDK: Results in path: "/" (leading slash issue)
        SDK->>Server: GET /file?path="/"
        Note over Server: May cause incorrect path resolution
    else After Fix
        FileContext->>FileContext: listPath = "" ? "" : "" + "/"
        Note over FileContext: listPath = ""
        FileContext->>SDK: file.list({ path: "" })
        SDK->>Server: GET /file?path=""
        Server->>FileContext: Returns correct root listing
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->