### PR TITLE
feat(app): add image preview support in session viewer

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1153,6 +1153,15 @@ export default function Page() {
                     })
                     const contents = createMemo(() => state()?.content?.content ?? "")
                     const cacheKey = createMemo(() => checksum(contents()))
+                    const isImage = createMemo(() => {
+                      const c = state()?.content
+                      return c?.encoding === "base64" && c?.mimeType?.startsWith("image/")
+                    })
+                    const imageDataUrl = createMemo(() => {
+                      if (!isImage()) return
+                      const c = state()?.content
+                      return `data:${c?.mimeType};base64,${c?.content}`
+                    })
                     const selectedLines = createMemo(() => {
                       const p = path()
                       if (!p) return null
@@ -1255,6 +1264,11 @@ export default function Page() {
                           )}
                         </Show>
                         <Switch>
+                          <Match when={state()?.loaded && isImage()}>
+                            <div class="px-6 py-4 pb-40">
+                              <img src={imageDataUrl()} alt={path()} class="max-w-full" />
+                            </div>
+                          </Match>
                           <Match when={state()?.loaded}>
                             <Dynamic
                               component={codeComponent}


### PR DESCRIPTION
Add ability to preview base64-encoded images directly in the session viewer instead of showing raw base64 data. Detects images by checking for base64 encoding and image/* mimeType, then renders them with an img element.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>


Added image preview support to the session viewer by detecting base64-encoded images and rendering them with an `<img>` element instead of displaying raw base64 data.

- Added `isImage` memo to check for base64 encoding and image MIME type
- Added `imageDataUrl` memo to construct data URL from base64 content
- Added new `<Match>` case in `<Switch>` to render image preview before the code viewer case
- Image preview uses `max-w-full` class for responsive sizing


</details>
<details open><summary><h3>Confidence Score: 4/5</h3></summary>


- This PR is safe to merge with low risk
- The implementation is straightforward and well-structured, using memoized computations to efficiently detect and render base64 images. The code properly checks for both base64 encoding and image MIME types before rendering. The new `<Match>` case is placed appropriately before the default code viewer. One minor consideration is the lack of error handling for malformed images, but this is acceptable for an initial implementation.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/app/src/pages/session.tsx | Added image preview detection and rendering for base64-encoded images in session viewer. Implementation uses memoized computations and properly checks for base64 encoding and image MIME type before rendering. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant SessionViewer as Session Viewer
    participant FileState as File State
    participant ImageDetection as Image Detection
    participant Renderer
    
    User->>SessionViewer: Open file tab
    SessionViewer->>FileState: Get file content state
    FileState-->>SessionViewer: Return FileContent object
    SessionViewer->>ImageDetection: Check isImage memo
    ImageDetection->>ImageDetection: Verify encoding is base64
    ImageDetection->>ImageDetection: Verify mimeType starts with image
    ImageDetection-->>SessionViewer: Return true or false
    
    alt Image detected
        SessionViewer->>ImageDetection: Call imageDataUrl memo
        ImageDetection->>ImageDetection: Build data URL string
        ImageDetection-->>SessionViewer: Return data URL
        SessionViewer->>Renderer: Render img element
        Renderer-->>User: Display image preview
    else Not an image
        SessionViewer->>Renderer: Render code viewer
        Renderer-->>User: Display code content
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->