### PR TITLE
Fix/tui attach directory

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -67,6 +67,7 @@ import { Footer } from "./footer.tsx"
 import { usePromptRef } from "../../context/prompt"
 import { Filesystem } from "@/util/filesystem"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
+import { normalizePathFromDirectory } from "@tui/util/paths"
 
 addDefaultParsers(parsers.parsers)
 
@@ -1880,12 +1881,8 @@ ToolRegistry.register<typeof TodoWriteTool>({
 })
 
 function normalizePath(input?: string) {
-  if (!input) return ""
-  if (path.isAbsolute(input)) {
-    const directory = use().sync.data.path.directory || process.cwd()
-    return path.relative(directory, input) || "."
-  }
-  return input
+  const directory = use().sync.data.path.directory || process.cwd()
+  return normalizePathFromDirectory(input, directory)
 }
 
 function input(input: Record<string, any>, omit?: string[]): string {

--- a/packages/opencode/src/cli/cmd/tui/util/paths.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/paths.ts
@@ -1,0 +1,9 @@
+import path from "path"
+
+export function normalizePathFromDirectory(input: string | undefined, directory: string) {
+  if (!input) return ""
+  if (path.isAbsolute(input)) {
+    return path.relative(directory, input) || "."
+  }
+  return input
+}

--- a/packages/opencode/test/tui/paths.test.ts
+++ b/packages/opencode/test/tui/paths.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { normalizePathFromDirectory } from "../../src/cli/cmd/tui/util/paths"
+
+describe("normalizePathFromDirectory", () => {
+  test("returns relative path for absolute input", () => {
+    const directory = "/tmp/opencode-test"
+    const input = path.join(directory, "src", "index.ts")
+    expect(normalizePathFromDirectory(input, directory)).toBe(path.join("src", "index.ts"))
+  })
+
+  test("keeps relative input unchanged", () => {
+    const directory = "/tmp/opencode-test"
+    const input = "src/index.ts"
+    expect(normalizePathFromDirectory(input, directory)).toBe(input)
+  })
+
+  test("returns dot when input equals base directory", () => {
+    const directory = "/tmp/opencode-test"
+    expect(normalizePathFromDirectory(directory, directory)).toBe(".")
+  })
+
+  test("returns empty string for empty input", () => {
+    const directory = "/tmp/opencode-test"
+    expect(normalizePathFromDirectory("", directory)).toBe("")
+  })
+})


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>


This PR fixes directory handling in the TUI attach command by properly passing the working directory context through the entire application stack.

- Passes `--dir` argument from attach command through TUI initialization to SDK client via `x-opencode-directory` header
- Refactors multiple components to use `sync.data.path.directory` instead of `process.cwd()` for file operations
- Introduces `normalizePathFromDirectory` utility function with comprehensive test coverage
- Ensures consistent directory context for file autocomplete, theme discovery, exports, and path normalization


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with no identified issues
- Clean implementation with proper parameter threading, comprehensive test coverage for new utility function, consistent pattern usage across all affected components, and no breaking changes to existing functionality
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/opencode/src/cli/cmd/tui/attach.ts | Passes directory from attach command to TUI, enabling proper working directory context |
| packages/opencode/src/cli/cmd/tui/context/sdk.tsx | Accepts directory parameter and passes to SDK client via x-opencode-directory header |
| packages/opencode/src/cli/cmd/tui/util/paths.ts | New utility function for normalizing paths relative to a specified directory |
| packages/opencode/src/cli/cmd/tui/routes/session/index.tsx | Refactored to use normalizePathFromDirectory helper and directory context for exports |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant AttachCmd as attach.ts
    participant TUI as app.tsx
    participant SDK as SDKProvider
    participant Client as SDK Client
    participant Server as Server
    participant Sync as sync.data.path
    participant Components as TUI Components

    User->>AttachCmd: opencode attach --dir /path
    AttachCmd->>AttachCmd: directory = args.dir || process.cwd()
    AttachCmd->>TUI: tui({ url, args, directory })
    TUI->>SDK: SDKProvider({ url, directory })
    SDK->>Client: createOpencodeClient({ baseUrl, directory })
    Client->>Client: Set header: x-opencode-directory
    Client->>Server: HTTP requests with x-opencode-directory header
    Server->>Server: Extract directory from header
    Server->>Sync: Populate sync.data.path.directory
    Sync->>Components: sync.data.path.directory available
    Components->>Components: Use directory for:<br/>- File autocomplete URLs<br/>- Custom theme discovery<br/>- Export operations<br/>- Path normalization
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->