### PR TITLE
fix: resolve bun global install postinstall block

### DIFF
--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -23,8 +23,7 @@ for (const name of Object.keys(binaries)) {
 }
 
 await $`mkdir -p ./dist/${pkg.name}`
-await $`mkdir -p ./dist/${pkg.name}/bin`
-await $`cp ./postinstall.mjs ./dist/${pkg.name}/postinstall.mjs`
+await $`cp -r ./bin ./dist/${pkg.name}/bin`
 
 await Bun.file(`./dist/${pkg.name}/package.json`).write(
   JSON.stringify(
@@ -32,9 +31,6 @@ await Bun.file(`./dist/${pkg.name}/package.json`).write(
       name: "shuvcode",
       bin: {
         shuvcode: "./bin/shuvcode",
-      },
-      scripts: {
-        postinstall: "node ./postinstall.mjs",
       },
       version: Script.version,
       // Reference our own binary packages (shuvcode-linux-x64, etc.)


### PR DESCRIPTION
## Summary

This PR fixes an issue where `bun install -g shuvcode` would fail to add the binary to the PATH because the postinstall script was blocked by Bun's security model.

## Changes

### Fixes

- Removed `postinstall.mjs` dependency from `packages/opencode/script/publish.ts`.
- Updated the publishing process to include the pre-built JavaScript launcher script in `bin/shuvcode`.
- Configured `package.json` to use the launcher script directly for the `shuvcode` binary.

## Breaking Changes

None.

## Testing

Verified that the launcher script correctly locates and executes the platform-specific binary in a simulated global install environment.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>


Eliminated postinstall script in favor of a pre-built Node.js launcher script to fix `bun install -g shuvcode` failures. Bun blocks postinstall scripts during global installs for security reasons, which prevented the binary from being properly set up in PATH.

**Key Changes:**
- Removed `postinstall.mjs` from the published package and its `scripts.postinstall` entry in `package.json`
- Now ships the pre-built `bin/shuvcode` launcher script directly in the published package
- The launcher dynamically locates and executes platform-specific binaries at runtime (same logic as the old postinstall script, but runs on-demand)
- Simplified publish process by copying the entire `bin/` directory instead of creating it and copying postinstall separately

**Technical Approach:**
The launcher script uses the same binary discovery logic (platform/arch detection, searching `node_modules` for `shuvcode-{platform}-{arch}` packages, baseline variant fallback) but executes at runtime rather than during installation. This bypasses Bun's security restrictions while maintaining identical functionality.


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The change is a well-designed architectural fix that solves a real installation problem. The launcher script contains the exact same binary discovery logic as the old postinstall script, just executed at runtime instead of install-time. The approach is cleaner (no install-time side effects), more secure (passes Bun's security model), and functionally equivalent. The smoke test in the publish script validates the change works correctly.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/opencode/script/publish.ts | Replaced postinstall script with pre-built launcher to avoid Bun security block during global install |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant BunInstall as bun install -g
    participant Package as shuvcode package
    participant Launcher as bin/shuvcode
    participant Binary as shuvcode-{platform}-{arch}

    User->>BunInstall: bun install -g shuvcode
    BunInstall->>Package: Install main package
    BunInstall->>Binary: Install optional dependency
    Note over Package: No postinstall script runs<br/>(Bun blocks it)
    Package-->>User: Installation complete

    User->>Launcher: Execute shuvcode command
    Launcher->>Launcher: Detect platform & arch
    Launcher->>Launcher: Search node_modules for binary
    Launcher->>Binary: Find shuvcode-{platform}-{arch}/bin/shuvcode
    Launcher->>Binary: spawn(binary, args)
    Binary-->>User: Execute command
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->