### PR TITLE
fix(tui): restore Linux paste support lost in upstream merge

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -20,6 +20,7 @@ import { useRenderer } from "@opentui/solid"
 import { Editor } from "@tui/util/editor"
 import { useExit } from "../../context/exit"
 import { Clipboard } from "../../util/clipboard"
+import { parseUriList } from "../../util/uri"
 import type { FilePart } from "@opencode-ai/sdk/v2"
 import { TuiEvent } from "../../event"
 import { iife } from "@/util/iife"
@@ -940,6 +941,39 @@ export function Prompt(props: PromptProps) {
                 if (!pastedContent) {
                   command.trigger("prompt.paste")
                   return
+                }
+
+                // Handle file:// URIs or text/uri-list (common for drag-and-drop on Linux)
+                if (pastedContent.includes("file://")) {
+                  const paths = parseUriList(pastedContent)
+                  if (paths.length > 0) {
+                    let handled = false
+                    for (const path of paths) {
+                      try {
+                        const file = Bun.file(path)
+                        if (file.type.startsWith("image/")) {
+                          const content = await file
+                            .arrayBuffer()
+                            .then((buffer) => Buffer.from(buffer).toString("base64"))
+                            .catch(() => {})
+                          if (content) {
+                            await pasteImage({
+                              filename: file.name,
+                              mime: file.type,
+                              content,
+                            })
+                            handled = true
+                            continue
+                          }
+                        }
+                      } catch {}
+                    }
+
+                    if (handled) {
+                      event.preventDefault()
+                      return
+                    }
+                  }
                 }
 
                 // trim ' from the beginning and end of the pasted content. just

--- a/script/sync/fork-features.json
+++ b/script/sync/fork-features.json
@@ -1600,6 +1600,35 @@
           "markers": ["absorbLineRange", "lineRangeRegex", "updateFileUrl"]
         }
       ]
+    },
+    {
+      "pr": 230,
+      "title": "Linux/Ghostty drag-and-drop and clipboard image paste support",
+      "author": "fork",
+      "status": "fork-only",
+      "description": "Handle file:// URIs and text/uri-list format for Linux drag-and-drop. Added ctrl+shift+v keybind for Linux paste. Supports both Wayland and X11 display servers. Fixes image paste in terminal emulators like Ghostty.",
+      "files": [
+        "packages/opencode/src/cli/cmd/tui/util/uri.ts",
+        "packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx",
+        "packages/opencode/src/config/config.ts"
+      ],
+      "criticalCode": [
+        {
+          "file": "packages/opencode/src/cli/cmd/tui/util/uri.ts",
+          "description": "parseUriList() helper to parse file:// URIs and text/uri-list format",
+          "markers": ["export function parseUriList", "file://", "decodeURIComponent"]
+        },
+        {
+          "file": "packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx",
+          "description": "Import parseUriList and handle file:// URIs in onPaste handler",
+          "markers": ["import { parseUriList }", "pastedContent.includes(\"file://\")", "parseUriList(pastedContent)"]
+        },
+        {
+          "file": "packages/opencode/src/config/config.ts",
+          "description": "input_paste keybind includes ctrl+shift+v for Linux",
+          "markers": ["input_paste:", "ctrl+v,ctrl+shift+v"]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Restores Linux paste support that was lost during the sync: merge upstream v1.0.223 merge. The `parseUriList` import and file:// URI handling code were accidentally dropped.

## Changes

### Fixes

- Re-add `parseUriList` import to `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`
- Restore file:// URI handling in `onPaste` handler for Linux drag-and-drop support
- Handles `text/uri-list` format common in Linux terminal emulators (e.g., Ghostty)
- Works with both Wayland and X11 display servers

### Documentation

- Added entry in `script/sync/fork-features.json` to document this fork feature and prevent future regression during upstream merges

## Breaking Changes

None

## Testing

Manual testing on Linux:
1. Drag and drop an image file into the TUI prompt
2. Use Ctrl+Shift+V to paste from clipboard with file:// URIs
3. Verify image files are properly detected and pasted as base64

Closes #230

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>


This PR restores Linux drag-and-drop file paste support that was accidentally lost during the upstream v1.0.223 merge. The change re-adds the `parseUriList` import and file:// URI handling code to the `onPaste` handler, enabling Linux terminal emulators (like Ghostty) to properly handle dragged image files via the `text/uri-list` format.

**Key changes:**
- Re-added `parseUriList` import from `../../util/uri`
- Restored file:// URI detection and parsing in the `onPaste` handler
- Handles multiple dragged files and filters for image types
- Added fork-features.json entry to document this feature and prevent future regression

The implementation correctly handles the file:// URIs before the fallback regular filepath handling, preventing conflicts and ensuring both drag-and-drop (file:// format) and direct path pasting continue to work.


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk - it restores previously working functionality
- The changes are a straightforward restoration of code that was lost in an upstream merge. The implementation is identical to the original working version (commit fbfa2a96), handles edge cases properly with try-catch blocks, and includes proper documentation in fork-features.json to prevent future regression. No new functionality is introduced - this is purely a restoration.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx | Restored `parseUriList` import and file:// URI handling in onPaste handler for Linux drag-and-drop support |
| script/sync/fork-features.json | Added documentation entry for Linux paste support fork feature to prevent future regression |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Terminal as Terminal Emulator<br/>(Ghostty/Linux)
    participant onPaste as onPaste Handler
    participant parseUriList as parseUriList()
    participant BunFile as Bun.file()
    participant pasteImage as pasteImage()
    participant Editor as Editor/Input

    User->>Terminal: Drag & drop image file
    Terminal->>onPaste: PasteEvent with file://... URIs
    onPaste->>onPaste: Normalize line endings
    onPaste->>onPaste: Check if contains "file://"
    onPaste->>parseUriList: parseUriList(pastedContent)
    parseUriList->>parseUriList: Split lines, strip comments
    parseUriList->>parseUriList: Remove file:// prefix
    parseUriList->>parseUriList: Decode URI components
    parseUriList-->>onPaste: Array of file paths
    
    loop For each path
        onPaste->>BunFile: Bun.file(path)
        BunFile-->>onPaste: File object with type
        alt Image file detected
            onPaste->>BunFile: file.arrayBuffer()
            BunFile-->>onPaste: Image buffer
            onPaste->>onPaste: Convert to base64
            onPaste->>pasteImage: pasteImage({filename, mime, content})
            pasteImage->>Editor: Create extmark & insert virtual text
            pasteImage->>Editor: Add file part to prompt
            Editor-->>User: Display [Image N] placeholder
        else Not an image
            onPaste->>onPaste: Continue to next file
        end
    end
    
    alt At least one image handled
        onPaste->>onPaste: event.preventDefault()
    else No images handled
        onPaste->>onPaste: Fall through to regular filepath handling
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->