### PR TITLE
Add event stream reconnection and visibility handling

### DIFF
--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -12,26 +12,64 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
     const server = useServer()
     const abort = new AbortController()
 
-    const eventSdk = createOpencodeClient({
-      baseUrl: server.url,
-      signal: abort.signal,
-      fetch: platform.fetch,
-    })
     const emitter = createGlobalEmitter<{
       [key: string]: Event
     }>()
 
-    void (async () => {
-      const events = await eventSdk.global.event()
-      for await (const event of events.stream) {
-        emitter.emit(event.directory ?? "global", event.payload)
-      }
-    })().catch((error) => {
-      if (error.name === "AbortError") return
-      console.error("Event stream error:", error)
-    })
+    let currentStreamAbort: AbortController | null = null
 
-    onCleanup(() => abort.abort())
+    async function connectEventStream() {
+      if (currentStreamAbort) {
+        currentStreamAbort.abort()
+      }
+
+      currentStreamAbort = new AbortController()
+      const streamAbort = currentStreamAbort
+
+      const eventSdk = createOpencodeClient({
+        baseUrl: server.url,
+        signal: streamAbort.signal,
+        fetch: platform.fetch,
+      })
+
+      try {
+        const events = await eventSdk.global.event()
+        for await (const event of events.stream) {
+          if (streamAbort.signal.aborted) break
+          emitter.emit(event.directory ?? "global", event.payload)
+        }
+      } catch (error: any) {
+        if (error.name === "AbortError" || streamAbort.signal.aborted) return
+        console.error("Event stream error:", error)
+      }
+
+      if (!abort.signal.aborted && !streamAbort.signal.aborted) {
+        setTimeout(() => {
+          if (!abort.signal.aborted) {
+            connectEventStream()
+          }
+        }, 1000)
+      }
+    }
+
+    connectEventStream()
+
+    // Reconnect when tab regains visibility - browsers kill background SSE connections
+    function handleVisibilityChange() {
+      if (document.visibilityState === "visible" && !abort.signal.aborted) {
+        connectEventStream()
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+
+    onCleanup(() => {
+      abort.abort()
+      if (currentStreamAbort) {
+        currentStreamAbort.abort()
+      }
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
+    })
 
     const sdk = createOpencodeClient({
       baseUrl: server.url,


### PR DESCRIPTION
This helps when tabbing back-and-forth between browser tabs, as browsers kill background SSE connections.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>


Refactors SSE event stream handling to support automatic reconnection when streams end and when browser tabs regain visibility. Extracted connection logic into a reusable `connectEventStream()` function that manages its own `AbortController` for stream lifecycle.

- Moved SDK client creation inside `connectEventStream()` to create fresh instances per connection
- Added automatic 1-second delayed reconnection when streams complete
- Implemented visibility change listener to reconnect when tab becomes visible (addresses browser killing background SSE connections)
- Enhanced cleanup to abort both global and stream-specific controllers

**Critical issue found**: Race condition where visibility-triggered reconnection and timeout-based reconnection can execute concurrently, potentially creating multiple active streams. The pending `setTimeout` callback isn't cancelled when visibility change triggers a new connection.


</details>
<details open><summary><h3>Confidence Score: 3/5</h3></summary>


- Functional but has a race condition that could cause duplicate streams
- The implementation correctly handles visibility changes and reconnection, but the race condition between timeout-based and visibility-based reconnection could create multiple concurrent streams, wasting resources and potentially causing duplicate event processing
- packages/app/src/context/global-sdk.tsx needs race condition fix before merge
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/app/src/context/global-sdk.tsx | Adds SSE reconnection logic with visibility change handling; potential race condition with concurrent reconnection attempts |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant GlobalSDK
    participant EventStream
    participant Server

    Note over GlobalSDK: Component initialization
    GlobalSDK->>GlobalSDK: connectEventStream()
    GlobalSDK->>EventStream: Create new AbortController
    GlobalSDK->>Server: eventSdk.global.event()
    Server-->>EventStream: SSE connection established
    
    loop Event streaming
        Server->>EventStream: Send event
        EventStream->>GlobalSDK: Receive event
        GlobalSDK->>GlobalSDK: emitter.emit(event)
    end

    alt Stream ends naturally
        EventStream->>GlobalSDK: Stream completes
        GlobalSDK->>GlobalSDK: setTimeout(reconnect, 1000)
        Note over GlobalSDK: Wait 1 second
        GlobalSDK->>GlobalSDK: connectEventStream()
    end

    alt Tab loses focus
        Browser->>Browser: Kill background SSE
        EventStream->>GlobalSDK: Connection dropped
    end

    alt Tab regains focus
        Browser->>GlobalSDK: visibilitychange event
        GlobalSDK->>GlobalSDK: handleVisibilityChange()
        GlobalSDK->>EventStream: Abort current stream
        GlobalSDK->>GlobalSDK: connectEventStream()
        Note right of GlobalSDK: Race: pending setTimeout<br/>may also fire
    end

    Note over GlobalSDK: Cleanup on unmount
    GlobalSDK->>EventStream: abort.abort()
    GlobalSDK->>Browser: removeEventListener()
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->