### PR TITLE
fix: restore plugin command execution and sessionOnly guard

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1497,6 +1497,73 @@ export namespace SessionPrompt {
       })
       throw error
     }
+
+    // Block session-only commands when session doesn't exist
+    // See fork-features.json: "Plugin command execution and sessionOnly guard"
+    if (command.sessionOnly) {
+      try {
+        await Session.get(input.sessionID)
+      } catch (error) {
+        const message = `/${command.name} requires an existing session`
+        log.warn("session-only command blocked", {
+          command: command.name,
+          sessionID: input.sessionID,
+          error,
+        })
+        Bus.publish(Session.Event.Error, {
+          sessionID: input.sessionID,
+          error: new NamedError.Unknown({
+            message,
+          }).toObject(),
+        })
+        throw new Error(message)
+      }
+    }
+
+    // Plugin commands execute directly via hook
+    // See fork-features.json: "Plugin command execution and sessionOnly guard"
+    if (command.type === "plugin") {
+      const plugins = await Plugin.list()
+      for (const plugin of plugins) {
+        const pluginCommands = plugin["plugin.command"]
+        const pluginCommand = pluginCommands?.[command.name]
+        if (!pluginCommand) continue
+
+        try {
+          const client = await Plugin.client()
+          await pluginCommand.execute({
+            sessionID: input.sessionID,
+            arguments: input.arguments,
+            client,
+          })
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          log.error("plugin command failed", { command: command.name, error: message })
+          Bus.publish(Session.Event.Error, {
+            sessionID: input.sessionID,
+            error: new NamedError.Unknown({
+              message: `/${command.name} failed: ${message}`,
+            }).toObject(),
+          })
+          throw error
+        }
+
+        // Emit event if plugin created a message
+        const last = await Session.messages({ sessionID: input.sessionID, limit: 1 })
+        if (last.length > 0) {
+          Bus.publish(Command.Event.Executed, {
+            name: command.name,
+            sessionID: input.sessionID,
+            arguments: input.arguments,
+            messageID: last[0].info.id,
+          })
+          return last[0]
+        }
+        return
+      }
+      return
+    }
+
     const agentName = command.agent ?? input.agent ?? (await Agent.defaultAgent())
 
     const raw = input.arguments.match(argsRegex) ?? []

--- a/script/sync/fork-features.json
+++ b/script/sync/fork-features.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Fork-specific features from upstream PRs that must be preserved during merges",
   "lastUpdated": "2026-01-07",
-  "lastChange": "Cherry-picked PR #5432: Stream ripgrep output in grep tool to prevent memory exhaustion. Also added spinner support for all running tool calls.",
-  "note": "v1.1.6 sync. Fork includes streaming grep optimization, spinner for all tool calls, and critical PWA/SDK fixes.",
+  "lastChange": "Restored plugin command execution and sessionOnly guard that was lost during v1.1.6 merge.",
+  "note": "v1.1.6 sync. Fork includes streaming grep optimization, spinner for all tool calls, plugin command execution, and critical PWA/SDK fixes.",
   "forkDependencies": {
     "description": "NPM dependencies added by fork features that MUST be preserved during package.json merges. These are frequently lost when accepting upstream version bumps.",
     "packages/opencode/package.json": [
@@ -1801,6 +1801,27 @@
           "markers": ["MATCH_LIMIT", "reader.read()", "proc.kill()", "truncated"]
         }
       ]
+    },
+    {
+      "pr": 0,
+      "title": "Plugin command execution and sessionOnly guard",
+      "author": "fork",
+      "status": "fork-only",
+      "description": "Execute plugin commands directly via plugin hooks instead of treating them as templates. Includes sessionOnly guard to block commands that require an existing session. Lost during v1.1.6 merge and restored.",
+      "files": ["packages/opencode/src/session/prompt.ts"],
+      "criticalCode": [
+        {
+          "file": "packages/opencode/src/session/prompt.ts",
+          "description": "SessionOnly guard checks if session exists before executing command",
+          "markers": ["command.sessionOnly", "Session.get(input.sessionID)", "requires an existing session"]
+        },
+        {
+          "file": "packages/opencode/src/session/prompt.ts",
+          "description": "Plugin command execution via plugin hooks with error handling",
+          "markers": ["command.type === \"plugin\"", "Plugin.list()", "pluginCommand.execute", "Plugin.client()"]
+        }
+      ],
+      "note": "This code was originally added in commit 57ac84410 but lost during v1.1.6 upstream merge. Tests in test/command/plugin-commands.test.ts verify this behavior."
     }
   ]
 }


### PR DESCRIPTION
## Summary

This PR completes the v1.1.6 integration by fixing plugin command execution that was lost during the merge.

## Changes from v1.1.6 Upstream Sync

### Features
- **Truncation system**: New configurable limits (2000 lines, 50KB bytes) with head/tail direction support for all tool outputs
- **Permission enhancements**: `PermissionNext` with wildcard pattern matching
- **Console billing**: Stripe webhook handlers for checkout, subscriptions, payments, and refunds
- **Desktop Tauri**: Enhanced entitlements and lib.rs improvements
- **Zed extension**: Updated to match upstream v1.1.6

### Fixes
- `fix(grep)`: Stream ripgrep output line-by-line to prevent memory exhaustion on large codebases (PR #5432)
- `fix`: Show spinner indicator for running tool calls and subagent tasks
- `fix(pwa)`: Lock viewport on iOS to prevent overscroll bounce in PWA standalone mode
- `fix(bedrock)`: Handle bundled AWS SDK export shapes from Bun with robust coalescing logic
- `fix`: Resolve TypeScript errors in theme.tsx and prompt.ts
- `fix`: Restore plugin command execution and sessionOnly guard (lost during merge)

## Plugin Command Fix Details

Restored two critical pieces of code lost during v1.1.6 merge:

1. **sessionOnly guard** - Checks if command requires existing session, throws appropriate error if missing
2. **Plugin command execution** - Direct execution via plugin hooks instead of treating as templates

### Files Modified
- `packages/opencode/src/session/prompt.ts` - Restored sessionOnly and plugin execution code
- `script/sync/fork-features.json` - Documented feature to prevent future merge regressions

## Testing

All tests pass including:
- Bedrock bundled module export tests
- Truncation tests
- Permission task tests
- Plugin command tests (4 tests):
  - `Command.get resolves plugin aliases`
  - `SessionPrompt.command executes plugin command`
  - `SessionPrompt.command publishes error on plugin failure`
  - `SessionPrompt.command blocks session-only commands for missing sessions`

## Breaking Changes

None

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>


Restores two critical plugin command features that were lost during the v1.1.6 upstream merge:

- **sessionOnly guard**: Validates that session-only commands have an existing session before execution, throwing appropriate errors if missing
- **Plugin command execution**: Executes plugin commands directly via plugin hooks instead of treating them as templates

The implementation follows existing patterns with proper error handling, logging, and event publishing. The `fork-features.json` documentation prevents future merge regressions by documenting the code markers to preserve.


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge - it restores previously working code with comprehensive test coverage
- The changes are well-tested (4 dedicated tests in plugin-commands.test.ts), follow existing code patterns, include proper error handling and logging, and restore functionality that was previously working before being lost in a merge
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/opencode/src/session/prompt.ts | Restores plugin command execution and sessionOnly guard that was lost during v1.1.6 merge. Clean implementation with proper error handling and logging. |
| script/sync/fork-features.json | Documents the restored fork-specific feature to prevent future merge regressions. Well-documented with file markers and descriptions. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant SessionPrompt
    participant Command
    participant Session
    participant Plugin
    participant Bus

    User->>SessionPrompt: command(input)
    SessionPrompt->>Command: get(command)
    Command-->>SessionPrompt: command info

    alt command.sessionOnly is true
        SessionPrompt->>Session: get(sessionID)
        alt Session not found
            Session-->>SessionPrompt: error
            SessionPrompt->>Bus: publish(Session.Event.Error)
            SessionPrompt-->>User: throw Error
        else Session found
            Session-->>SessionPrompt: session
        end
    end

    alt command.type === "plugin"
        SessionPrompt->>Plugin: list()
        Plugin-->>SessionPrompt: plugins[]
        loop for each plugin
            SessionPrompt->>Plugin: client()
            Plugin-->>SessionPrompt: client
            SessionPrompt->>Plugin: pluginCommand.execute()
            alt execution fails
                Plugin-->>SessionPrompt: error
                SessionPrompt->>Bus: publish(Session.Event.Error)
                SessionPrompt-->>User: throw error
            else execution succeeds
                SessionPrompt->>Session: messages({limit: 1})
                Session-->>SessionPrompt: messages[]
                alt messages exist
                    SessionPrompt->>Bus: publish(Command.Event.Executed)
                    SessionPrompt-->>User: return last message
                else no messages
                    SessionPrompt-->>User: return undefined
                end
            end
        end
    else command.type === "template"
        SessionPrompt->>SessionPrompt: process template
        SessionPrompt-->>User: return result
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->