### PR TITLE
feat: enable AskQuestion tool by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,19 +213,9 @@ Toggle density from the command palette or set in config:
 
 ---
 
-### AskQuestion Tool (Experimental)
+### AskQuestion Tool
 
-Enable the AI to pause and ask structured questions via a wizard UI. Available in both TUI and web app.
-
-Enable in `opencode.json`:
-
-```jsonc
-{
-  "experimental": {
-    "askquestion_tool": true,
-  },
-}
-```
+The AI can pause and ask structured questions via a wizard UI. Available in both TUI and web app. This tool is enabled by default.
 
 Features:
 - Wizard-style multi-question dialogs with single/multi-select options

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -977,7 +977,6 @@ export namespace Config {
           chatMaxRetries: z.number().optional().describe("Number of retries for chat completions on failure"),
           disable_paste_summary: z.boolean().optional(),
           batch_tool: z.boolean().optional().describe("Enable the batch tool"),
-          askquestion_tool: z.boolean().optional().describe("Enable the askquestion tool for LLM to ask clarifying questions"),
           openTelemetry: z
             .boolean()
             .optional()

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -108,7 +108,7 @@ export namespace ToolRegistry {
       SkillTool,
       ...(Flag.OPENCODE_EXPERIMENTAL_LSP_TOOL ? [LspTool] : []),
       ...(config.experimental?.batch_tool === true ? [BatchTool] : []),
-      ...(config.experimental?.askquestion_tool === true ? [AskQuestionTool] : []),
+      AskQuestionTool,
       ...custom,
     ]
   }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1825,10 +1825,6 @@ export type Config = {
      */
     batch_tool?: boolean
     /**
-     * Enable the askquestion tool for LLM to ask clarifying questions
-     */
-    askquestion_tool?: boolean
-    /**
      * Enable OpenTelemetry spans for AI SDK calls (using the 'experimental_telemetry' flag)
      */
     openTelemetry?: boolean

--- a/script/sync/fork-features.json
+++ b/script/sync/fork-features.json
@@ -192,8 +192,7 @@
       "title": "AskQuestion tool for user input",
       "author": "iljod",
       "status": "open",
-      "description": "Interactive tool that allows AI to pause and solicit structured feedback via TUI/web wizard with single/multi-select and confirm dialogs. Fixes race conditions from PR 5563. Disabled by default - enable with experimental.askquestion_tool config. v1.1.4 improvements: callID validation, fallback scan detection for delayed messages, getMetadata/findInParts helpers.",
-      "experimentalConfig": "askquestion_tool",
+      "description": "Interactive tool that allows AI to pause and solicit structured feedback via TUI/web wizard with single/multi-select and confirm dialogs. Fixes race conditions from PR 5563. Enabled by default. v1.1.4 improvements: callID validation, fallback scan detection for delayed messages, getMetadata/findInParts helpers.",
       "files": [
         "packages/opencode/src/askquestion/index.ts",
         "packages/opencode/src/tool/askquestion.ts",
@@ -236,14 +235,9 @@
           "markers": ["/askquestion/respond", "/askquestion/cancel", "AskQuestion.respond", "AskQuestion.cancel"]
         },
         {
-          "file": "packages/opencode/src/config/config.ts",
-          "description": "Experimental config flag to enable askquestion tool",
-          "markers": ["askquestion_tool: z.boolean().optional()"]
-        },
-        {
           "file": "packages/opencode/src/tool/registry.ts",
-          "description": "Conditional tool registration based on experimental config",
-          "markers": ["config.experimental?.askquestion_tool === true ? [AskQuestionTool]"]
+          "description": "AskQuestionTool registration (enabled by default)",
+          "markers": ["AskQuestionTool"]
         },
         {
           "file": "packages/app/src/components/askquestion-wizard.tsx",


### PR DESCRIPTION
## Summary

Enable the AskQuestion tool by default, removing the experimental flag requirement.

## Changes

### Features

- AskQuestion tool is now enabled for all users without configuration
- Removed `experimental.askquestion_tool` config option from schema

### Documentation

- Updated README.md to reflect the tool is enabled by default
- Updated fork-features.json to document the change

## Files Changed

- `packages/opencode/src/tool/registry.ts` - Include AskQuestionTool unconditionally
- `packages/opencode/src/config/config.ts` - Remove askquestion_tool from experimental config
- `README.md` - Update documentation
- `script/sync/fork-features.json` - Update feature documentation

## Breaking Changes

None. Users who had `experimental.askquestion_tool: true` configured will see no change. The config option is simply no longer required.

## Testing

Existing tests pass. The AskQuestion tool tests in `packages/opencode/test/` continue to work.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>


This PR promotes the AskQuestion tool from experimental to default-enabled status, removing the need for manual configuration. The changes properly remove the conditional logic in the tool registry and the experimental config flag from the schema.

- Removed `experimental.askquestion_tool` config option from the Zod schema
- Changed tool registration from conditional spread to direct inclusion in `registry.ts`
- Updated README.md to remove configuration instructions and mark as default-enabled
- Updated `fork-features.json` documentation to reflect new status

The implementation is clean and straightforward - users who had the experimental flag enabled will see no behavioral change, while others will now have the tool available automatically.


</details>
<details open><summary><h3>Confidence Score: 4/5</h3></summary>


- Safe to merge with one minor cleanup step needed
- The changes are well-structured and backward compatible. Only concern is the auto-generated SDK file needs regeneration to stay in sync with the config schema changes
- `packages/opencode/src/config/config.ts` - needs SDK regeneration after merge
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/opencode/src/tool/registry.ts | Removed conditional registration, AskQuestionTool now enabled by default |
| packages/opencode/src/config/config.ts | Removed askquestion_tool experimental config flag from schema |
| README.md | Updated docs to reflect tool is enabled by default, removed config instructions |
| script/sync/fork-features.json | Updated feature documentation to reflect default-enabled status |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Registry as ToolRegistry
    participant Config as Config Schema
    participant AskQuestion as AskQuestionTool

    Note over Registry,Config: Before PR (experimental flag)
    User->>Config: Reads opencode.json
    Config-->>User: experimental.askquestion_tool = true/false
    User->>Registry: Initialize tools
    Registry->>Config: Check experimental.askquestion_tool
    alt askquestion_tool === true
        Registry->>AskQuestion: Register AskQuestionTool
        Registry-->>User: Tools with AskQuestion
    else askquestion_tool !== true
        Registry-->>User: Tools without AskQuestion
    end

    Note over Registry,Config: After PR (default enabled)
    User->>Config: Reads opencode.json
    Note over Config: askquestion_tool removed from schema
    User->>Registry: Initialize tools
    Registry->>AskQuestion: Register AskQuestionTool unconditionally
    Registry-->>User: Tools with AskQuestion (always)
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->