### PR TITLE
Fix local plugin loading to preserve OAuth assets

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -7,6 +7,7 @@ import { Plugin } from "../plugin"
 import PROMPT_INITIALIZE from "./template/initialize.txt"
 import PROMPT_REVIEW from "./template/review.txt"
 import { MCP } from "../mcp"
+import type { Hooks } from "@opencode-ai/plugin"
 
 export namespace Command {
   export const Event = {
@@ -129,7 +130,7 @@ export namespace Command {
     // Plugin commands
     const plugins = await Plugin.list()
     for (const plugin of plugins) {
-      const commands = plugin["plugin.command"]
+      const commands: NonNullable<Hooks["plugin.command"]> | undefined = plugin["plugin.command"]
       if (!commands) continue
       for (const [name, cmd] of Object.entries(commands)) {
         if (result[name]) continue // Don't override existing commands

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -94,7 +94,7 @@ export namespace Plugin {
       fetch: async (...args) => Server.App().fetch(...args),
     })
     const config = await Config.get()
-    const hooks = []
+    const hooks: Hooks[] = []
     const input: PluginInput = {
       client,
       project: Instance.project,
@@ -193,7 +193,7 @@ export namespace Plugin {
     for (const hook of await state().then((x) => x.hooks)) {
       const fn = hook[name]
       if (!fn) continue
-      // @ts-expect-error if you feel adventurous, please fix the typing, make sure to bump the try-counter if you
+      // @ts-ignore if you feel adventurous, please fix the typing, make sure to bump the try-counter if you
       // give up.
       // try-counter: 2
       await fn(input, output)
@@ -213,7 +213,7 @@ export namespace Plugin {
     const hooks = await state().then((x) => x.hooks)
     const config = await Config.get()
     for (const hook of hooks) {
-      // @ts-expect-error this is because we haven't moved plugin to sdk v2
+      // @ts-ignore this is because we haven't moved plugin to sdk v2
       await hook.config?.(config)
     }
     Bus.subscribeAll(async (input) => {

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -83,6 +83,10 @@ export namespace Plugin {
     }
   }
 
+  function isModuleResolutionError(err: Error): boolean {
+    return err.message?.includes("Cannot find module") || err.message?.includes("Cannot find package")
+  }
+
   const state = Instance.state(async () => {
     const client = createOpencodeClient({
       baseUrl: "http://localhost:4096",
@@ -106,6 +110,7 @@ export namespace Plugin {
     for (let plugin of plugins) {
       log.info("loading plugin", { path: plugin })
       let pluginUrl: string
+      let localPluginPath: string | undefined
       if (!plugin.startsWith("file://")) {
         const lastAtIndex = plugin.lastIndexOf("@")
         const pkg = lastAtIndex > 0 ? plugin.substring(0, lastAtIndex) : plugin
@@ -122,14 +127,14 @@ export namespace Plugin {
         // Resolve relative file:// paths against the working directory
         const filePath = plugin.substring("file://".length)
         const absolutePath = path.isAbsolute(filePath) ? filePath : path.resolve(Instance.directory, filePath)
-        // Bundle local plugins with their dependencies for compiled binary compatibility
-        const bundledPath = await bundleLocalPlugin(absolutePath)
-        pluginUrl = pathToFileURL(bundledPath).href
+        localPluginPath = absolutePath
+        pluginUrl = pathToFileURL(absolutePath).href
       }
-      try {
+
+      const loadPluginModule = async (url: string) => {
         // Use dynamic import() with absolute file:// URLs for ES module compatibility
         // pathToFileURL ensures proper URL encoding regardless of import.meta.url context
-        const mod = await import(pluginUrl)
+        const mod = await import(url)
         // Prevent duplicate initialization when plugins export the same function
         // as both a named export and default export (e.g., `export const X` and `export default X`).
         // Object.entries(mod) would return both entries pointing to the same function reference.
@@ -141,10 +146,23 @@ export namespace Plugin {
           const init = await fn(input)
           hooks.push(init)
         }
+      }
+
+      try {
+        await loadPluginModule(pluginUrl)
       } catch (e) {
         const err = e as Error
+        if (localPluginPath && isModuleResolutionError(err)) {
+          log.warn("failed to load local plugin directly, bundling fallback", {
+            plugin,
+            error: err.message,
+          })
+          const bundledPath = await bundleLocalPlugin(localPluginPath)
+          await loadPluginModule(pathToFileURL(bundledPath).href)
+          continue
+        }
         // Check for module resolution issues
-        if (err.message?.includes("Cannot find module") || err.message?.includes("Cannot find package")) {
+        if (isModuleResolutionError(err)) {
           log.error("failed to load plugin", {
             plugin,
             error: err.message,

--- a/packages/opencode/src/provider/auth.ts
+++ b/packages/opencode/src/provider/auth.ts
@@ -30,14 +30,15 @@ export namespace ProviderAuth {
 
   export async function methods() {
     const s = await state().then((x) => x.methods)
-    return mapValues(s, (x: Hooks["auth"]) =>
-      x.methods.map(
+    return mapValues(s, (x: Hooks["auth"] | undefined) => {
+      if (!x) return []
+      return x.methods.map(
         (method): Method => ({
           type: method.type,
           label: method.label,
         }),
-      ),
-    )
+      )
+    })
   }
 
   export const Authorization = z

--- a/packages/opencode/src/provider/auth.ts
+++ b/packages/opencode/src/provider/auth.ts
@@ -30,11 +30,11 @@ export namespace ProviderAuth {
 
   export async function methods() {
     const s = await state().then((x) => x.methods)
-    return mapValues(s, (x) =>
+    return mapValues(s, (x: Hooks["auth"]) =>
       x.methods.map(
-        (y): Method => ({
-          type: y.type,
-          label: y.label,
+        (method): Method => ({
+          type: method.type,
+          label: method.label,
         }),
       ),
     )

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -50,7 +50,9 @@ export namespace ToolRegistry {
 
     const plugins = await Plugin.list()
     for (const plugin of plugins) {
-      for (const [id, def] of Object.entries(plugin.tool ?? {})) {
+      const tools = plugin.tool as Record<string, ToolDefinition> | undefined
+      if (!tools) continue
+      for (const [id, def] of Object.entries(tools)) {
         custom.push(fromPlugin(id, def))
       }
     }


### PR DESCRIPTION
## Summary

Load local file:// plugins directly to preserve asset-relative paths used by OAuth plugins, with a bundling fallback only when module resolution fails.

## Changes

### Fixes

- Load local plugins directly instead of bundling by default.
- Fall back to bundling for local plugins when direct import fails due to missing modules.
- Centralize module resolution error detection for clearer logging.
- Resolve typecheck issues triggered by plugin loading changes.

## Breaking Changes

None

## Testing

bun turbo typecheck

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR modifies the plugin loading mechanism to load local `file://` plugins directly instead of bundling them by default, which preserves asset-relative paths needed for OAuth plugins. The bundling process now only occurs as a fallback when direct module import fails due to missing dependencies.

## Key Changes

**Plugin Loading Strategy**: The core change inverts the loading approach - instead of always bundling local plugins first, the code now attempts to load them directly via dynamic import. This preserves the plugin's original file structure and relative paths, which is critical for OAuth plugins that reference HTML assets for callback pages.

**Fallback Mechanism**: When direct loading fails with a module resolution error (missing dependencies), the code falls back to the original bundling approach, which resolves all dependencies into a single file.

**Type Safety Improvements**: The PR includes several typecheck fixes across multiple files, adding explicit type annotations and defensive null checks to handle potentially undefined plugin hooks.

## Integration Points

The changes integrate cleanly with the existing plugin architecture:
- The `bundleLocalPlugin` function remains intact and is now used conditionally
- Asset copying still occurs when bundling happens
- Plugin hooks and initialization flow are unchanged
- The `isModuleResolutionError` helper centralizes error detection logic

## Critical Issue Found

There is a logic error in the error handling where the bundled plugin load attempt (line 161) is not wrapped in a try-catch. If the bundled version fails to load, the error will propagate uncaught, bypassing proper error logging and potentially failing the entire plugin initialization process instead of just logging and skipping the problematic plugin.

### Confidence Score: 2/5

- This PR has a critical error handling bug that could cause plugin loading to fail unexpectedly
- The core plugin loading logic has a significant error handling gap where the bundling fallback path is not properly wrapped in error handling. This means if a bundled plugin fails to load (for any reason), the error will not be caught and could crash the plugin loading process. While the type safety improvements in the other files are solid, this critical logic error in the main plugin loading file significantly impacts the overall safety score.
- packages/opencode/src/plugin/index.ts requires immediate attention to fix the error handling around the bundling fallback (lines 155-162)

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/opencode/src/plugin/index.ts | 2/5 | Changes plugin loading to try direct import first with bundling fallback, but has critical error handling bug where bundled plugin load failures aren't caught |
| packages/opencode/src/command/index.ts | 5/5 | Adds explicit type annotation for plugin commands to fix typecheck issues, no functional changes |
| packages/opencode/src/provider/auth.ts | 5/5 | Adds defensive null check and explicit typing for auth methods, improving runtime safety |
| packages/opencode/src/tool/registry.ts | 5/5 | Refactors plugin tools extraction with explicit type assertion and null check, cleaner and safer |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Config
    participant Plugin as Plugin.state()
    participant Loader as loadPluginModule
    participant Bundler as bundleLocalPlugin
    participant Import as dynamic import()

    Config->>Plugin: Get plugin list
    
    loop For each plugin
        alt Non-local plugin (npm)
            Plugin->>Plugin: Install via BunProc
            Plugin->>Import: import(npmPluginUrl)
            Import-->>Plugin: Module loaded
        else Local plugin (file://)
            Plugin->>Plugin: Resolve absolute path
            Note over Plugin: NEW: Try direct load first
            Plugin->>Loader: loadPluginModule(fileUrl)
            Loader->>Import: import(fileUrl)
            
            alt Import succeeds
                Import-->>Loader: Module loaded
                Loader-->>Plugin: Hooks initialized
            else Import fails (module error)
                Import-->>Loader: Error: Cannot find module
                Loader-->>Plugin: Throw error
                Note over Plugin: Check if module resolution error
                Plugin->>Bundler: bundleLocalPlugin(localPath)
                Bundler->>Bundler: Bun.build() with dependencies
                Bundler->>Bundler: Copy assets to cache
                Bundler-->>Plugin: Return bundled path
                Note over Plugin: ISSUE: Not wrapped in try-catch
                Plugin->>Loader: loadPluginModule(bundledUrl)
                Loader->>Import: import(bundledUrl)
                
                alt Bundled import succeeds
                    Import-->>Loader: Module loaded
                    Loader-->>Plugin: Hooks initialized
                else Bundled import fails
                    Import-->>Loader: Error (uncaught!)
                    Note over Plugin,Import: BUG: Error propagates uncaught
                end
            end
        end
    end
    
    Plugin-->>Config: Return hooks array
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->