### PR TITLE
Harden local plugin bundling fallback

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -84,7 +84,11 @@ export namespace Plugin {
   }
 
   function isModuleResolutionError(err: Error): boolean {
-    return err.message?.includes("Cannot find module") || err.message?.includes("Cannot find package")
+    return (
+      err.message?.includes("Cannot find module") ||
+      err.message?.includes("Cannot find package") ||
+      (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND"
+    )
   }
 
   const state = Instance.state(async () => {
@@ -157,9 +161,18 @@ export namespace Plugin {
             plugin,
             error: err.message,
           })
-          const bundledPath = await bundleLocalPlugin(localPluginPath)
-          await loadPluginModule(pathToFileURL(bundledPath).href)
-          continue
+          try {
+            const bundledPath = await bundleLocalPlugin(localPluginPath)
+            await loadPluginModule(pathToFileURL(bundledPath).href)
+            continue
+          } catch (bundleErr) {
+            const bErr = bundleErr as Error
+            log.error("failed to load bundled plugin", {
+              plugin,
+              error: bErr.message,
+            })
+            throw bErr
+          }
         }
         // Check for module resolution issues
         if (isModuleResolutionError(err)) {


### PR DESCRIPTION
## Summary

Handle bundled plugin load failures explicitly and broaden module resolution error detection for more reliable logging.

## Changes

### Fixes

- Wrap bundled plugin load attempts with error logging.
- Treat MODULE_NOT_FOUND as a module resolution error.

## Breaking Changes

None

## Testing

bun turbo typecheck

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

Enhances local plugin bundling error handling by wrapping the fallback bundling attempt in a try-catch block with explicit error logging. Broadens module resolution error detection to include the `MODULE_NOT_FOUND` error code in addition to string-based error message checks.

### Confidence Score: 4/5

- Safe to merge with minimal risk
- The changes improve error handling robustness by adding explicit try-catch around bundled plugin loading and broadening error detection. The MODULE_NOT_FOUND check follows existing patterns in the codebase (storage.ts). Code is well-structured with appropriate logging. No functional issues identified.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/opencode/src/plugin/index.ts | 4/5 | Improves error detection by adding MODULE_NOT_FOUND code check and wraps bundled plugin fallback with proper error logging |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant PM as Plugin Manager
    participant LP as Local Plugin
    participant BP as Bundler
    participant LM as Load Module

    PM->>LP: loadPluginModule(pluginUrl)
    alt Direct load succeeds
        LP->>LM: import(url)
        LM-->>PM: Success
    else Direct load fails
        LP-->>PM: Error (MODULE_NOT_FOUND)
        PM->>PM: isModuleResolutionError?
        alt Is module resolution error
            PM->>BP: bundleLocalPlugin(localPluginPath)
            BP-->>PM: bundledPath
            PM->>LM: loadPluginModule(bundledPath)
            alt Bundle load succeeds
                LM-->>PM: Success
            else Bundle load fails
                LM-->>PM: Error
                PM->>PM: log.error("failed to load bundled plugin")
                PM->>PM: throw bundleErr
            end
        else Other error
            PM->>PM: log.error("failed to load plugin")
            PM->>PM: throw error
        end
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->