### PR TITLE
Add variant cycle tooltip in TUI prompt

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -714,9 +714,9 @@ export function Prompt(props: PromptProps) {
     return local.agent.color(local.agent.current().name)
   })
 
+  const hasVariants = createMemo(() => local.model.variant.list().length > 0)
   const showVariant = createMemo(() => {
-    const variants = local.model.variant.list()
-    if (variants.length === 0) return false
+    if (!hasVariants()) return false
     const current = local.model.variant.current()
     return !!current
   })
@@ -1120,6 +1120,11 @@ export function Prompt(props: PromptProps) {
                   <text fg={theme.text}>
                     {keybind.print("command_list")} <span style={{ fg: theme.textMuted }}>commands</span>
                   </text>
+                  <Show when={hasVariants()}>
+                    <text fg={theme.text}>
+                      {keybind.print("variant_cycle")} <span style={{ fg: theme.textMuted }}>cycle variants</span>
+                    </text>
+                  </Show>
                 </Match>
                 <Match when={store.mode === "shell"}>
                   <text fg={theme.text}>


### PR DESCRIPTION
## Summary\n- show variant cycle keybind hint in session prompt footer when variants are available\n- reuse variant availability memo for tooltip visibility\n\n## Testing\n- bun turbo typecheck