### PR TITLE
Add variant cycle tooltip in TUI prompt

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -694,9 +694,9 @@ export function Prompt(props: PromptProps) {
     return local.agent.color(local.agent.current().name)
   })
 
+  const hasVariants = createMemo(() => local.model.variant.list().length > 0)
   const showVariant = createMemo(() => {
-    const variants = local.model.variant.list()
-    if (variants.length === 0) return false
+    if (!hasVariants()) return false
     const current = local.model.variant.current()
     return !!current
   })
@@ -1068,6 +1068,11 @@ export function Prompt(props: PromptProps) {
                   <text fg={theme.text}>
                     {keybind.print("command_list")} <span style={{ fg: theme.textMuted }}>commands</span>
                   </text>
+                  <Show when={hasVariants()}>
+                    <text fg={theme.text}>
+                      {keybind.print("variant_cycle")} <span style={{ fg: theme.textMuted }}>cycle variants</span>
+                    </text>
+                  </Show>
                 </Match>
                 <Match when={store.mode === "shell"}>
                   <text fg={theme.text}>


### PR DESCRIPTION
## Summary\n- show variant cycle keybind hint in session prompt footer when variants are available\n- reuse variant availability memo for tooltip visibility\n\n## Testing\n- bun turbo typecheck

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR enhances the TUI prompt component by adding a helpful keybind hint for cycling through model variants when they are available. The implementation demonstrates good code quality with proper memoization and logical refactoring.

## Key Changes

1. **New `hasVariants` memo** - Extracts the variant availability check (`local.model.variant.list().length > 0`) into a reusable memoized value for better performance and code reuse

2. **Refactored `showVariant` memo** - Now depends on `hasVariants()` instead of calling `local.model.variant.list()` directly, maintaining the same logic while improving code clarity

3. **Added variant cycle tooltip** - Displays the configured keybind hint (default: `ctrl+t cycle variants`) in the prompt footer when variants are available, improving discoverability of this feature

## Implementation Quality

**Logic Correctness**: The distinction between `hasVariants` (shows tooltip when variants exist) and `showVariant` (shows variant badge only when one is selected) is intentional and correct. This ensures users see the keybind hint even when no variant is currently selected, helping them discover the feature.

**Performance**: The use of `createMemo` for `hasVariants` prevents unnecessary recalculations of variant list length, and sharing this memo between the tooltip and the refactored `showVariant` logic is efficient.

**Consistency**: The new tooltip follows the same styling patterns as the existing `agent_cycle` and `command_list` hints in the footer, maintaining UI consistency.

**Integration**: The keybind `variant_cycle` is properly configured in the config schema with a default value of `ctrl+t`, and the `variant.cycle()` function in local context correctly handles all edge cases (no variants, no selection, cycling through list).

### Confidence Score: 5/5

- This PR is safe to merge with no issues identified
- The changes are minimal, well-implemented, and thoroughly validated. The refactoring improves code quality through memo reuse, the new tooltip enhances UX by making the variant cycle feature discoverable, and all edge cases are properly handled. The implementation follows existing patterns in the codebase and integrates seamlessly with the existing variant cycling functionality.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx | 5/5 | Adds variant cycle keybind tooltip to prompt footer when variants are available. Refactors variant checking logic to use a shared memo for better performance and code reuse. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Prompt as Prompt Component
    participant Local as Local Context
    participant Keybind as Keybind Context
    participant UI as UI Render

    Note over Prompt: Component initialization
    Prompt->>Local: createMemo(() => local.model.variant.list().length > 0)
    Local-->>Prompt: hasVariants (boolean)
    
    Prompt->>Local: createMemo(() => hasVariants() && !!local.model.variant.current())
    Local-->>Prompt: showVariant (boolean)

    Note over Prompt: Footer rendering (line 1061-1084)
    Prompt->>Prompt: Check if hasVariants() is true
    
    alt Variants available
        Prompt->>Keybind: keybind.print("variant_cycle")
        Keybind-->>Prompt: "ctrl+t" (or configured keybind)
        Prompt->>UI: Render tooltip: "ctrl+t cycle variants"
        UI-->>User: Display variant cycle hint
    else No variants
        Prompt->>UI: Skip tooltip rendering
        UI-->>User: No variant cycle hint shown
    end

    Note over Prompt: Current variant display (line 944-949)
    Prompt->>Prompt: Check if showVariant() is true
    
    alt Variant selected
        Prompt->>Local: local.model.variant.current()
        Local-->>Prompt: Current variant name
        Prompt->>UI: Render variant badge
        UI-->>User: Display selected variant
    else No variant selected
        Prompt->>UI: Skip variant badge
        UI-->>User: No variant badge shown
    end

    Note over User: User interaction
    User->>User: Presses variant_cycle keybind (ctrl+t)
    User->>Local: Trigger variant.cycle()
    Local->>Local: Cycle through available variants
    Local-->>Prompt: Update triggers re-render
    Prompt->>UI: Update both tooltip and variant display
    UI-->>User: Show updated variant state
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->