### PR TITLE
Add variant cycle tooltip in TUI prompt

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -694,9 +694,9 @@ export function Prompt(props: PromptProps) {
     return local.agent.color(local.agent.current().name)
   })
 
+  const hasVariants = createMemo(() => local.model.variant.list().length > 0)
   const showVariant = createMemo(() => {
-    const variants = local.model.variant.list()
-    if (variants.length === 0) return false
+    if (!hasVariants()) return false
     const current = local.model.variant.current()
     return !!current
   })
@@ -1068,6 +1068,11 @@ export function Prompt(props: PromptProps) {
                   <text fg={theme.text}>
                     {keybind.print("command_list")} <span style={{ fg: theme.textMuted }}>commands</span>
                   </text>
+                  <Show when={hasVariants()}>
+                    <text fg={theme.text}>
+                      {keybind.print("variant_cycle")} <span style={{ fg: theme.textMuted }}>cycle variants</span>
+                    </text>
+                  </Show>
                 </Match>
                 <Match when={store.mode === "shell"}>
                   <text fg={theme.text}>


### PR DESCRIPTION
## Summary

Adds a helpful tooltip in the TUI prompt showing the keybind to cycle through model variants when variants are available.

## Changes

### Features

- Display variant cycle keybind tooltip when model variants are available
- Extract `hasVariants` memo for cleaner conditional logic

### Technical Details

- Added `hasVariants()` memo to check if variant list is non-empty
- Refactored `showVariant()` to use the new memo
- Added conditional `<Show>` block in prompt footer to display the variant cycle keybind

## Breaking Changes

None

## Testing

Existing tests cover changes. Manual verification:
1. Open TUI with a model that has variants configured
2. Verify the "cycle variants" tooltip appears in the prompt footer
3. Verify tooltip is hidden when no variants are available

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds a helpful tooltip in the TUI prompt footer that displays the keybind for cycling through model variants when variants are available.

## Key Changes

- **Extracted `hasVariants()` memo**: Refactored the variant availability check into a reusable computed value that checks if `local.model.variant.list().length > 0`
- **Refactored `showVariant()`**: Updated to use the new `hasVariants()` memo instead of duplicating the check, improving code maintainability
- **Added conditional tooltip**: Introduced a `<Show when={hasVariants()}>` block in the prompt footer that displays the variant cycle keybind (`ctrl+t` by default) alongside existing keybind hints like "switch agent" and "commands"

## Implementation Quality

The implementation follows existing patterns in the codebase:
- Consistent with other keybind tooltips in the same section (agent_cycle, command_list)
- Properly nested within the correct conditional rendering blocks (Show when status is not retry, Match when mode is normal)
- Uses the same text styling pattern as adjacent tooltips

The refactoring improves code quality by eliminating duplicate logic and making the intent clearer. The new tooltip provides discoverability for the variant cycling feature, which is particularly useful for models that support thinking variants (like o1-preview, o1-mini, deepseek-r1, etc.).

## Testing Considerations

The change affects UI rendering in the prompt footer. Manual testing should verify:
1. Tooltip appears when a model with variants is selected
2. Tooltip is hidden when no variants are available
3. Proper alignment with other tooltips in the footer
4. Correct keybind is displayed (defaults to ctrl+t)

### Confidence Score: 5/5

- This PR is safe to merge with no identified risks
- The changes are minimal, well-isolated, and follow established patterns. The refactoring improves code quality by extracting a reusable memo. The new conditional tooltip is properly placed and doesn't affect any business logic. No edge cases or potential bugs were found during thorough analysis.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx | 5/5 | Added variant cycle keybind tooltip with clean refactoring of hasVariants check - no issues found |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant TUI as TUI Prompt Component
    participant Local as Local Context
    participant Keybind as Keybind Context
    
    User->>TUI: Opens prompt with model selected
    TUI->>Local: local.model.variant.list()
    Local-->>TUI: Returns variants array
    TUI->>TUI: hasVariants() memo evaluates
    
    alt Has variants (length > 0)
        TUI->>TUI: hasVariants() returns true
        TUI->>TUI: showVariant() checks current variant
        TUI->>Local: local.model.variant.current()
        Local-->>TUI: Returns current variant or undefined
        
        alt Current variant exists
            TUI->>TUI: Display variant name in prompt info
        end
        
        TUI->>Keybind: keybind.print("variant_cycle")
        Keybind-->>TUI: Returns "ctrl+t" (default)
        TUI->>User: Displays tooltip: "ctrl+t cycle variants"
    else No variants (length = 0)
        TUI->>TUI: hasVariants() returns false
        TUI->>User: Tooltip hidden
    end
    
    User->>User: Presses ctrl+t
    User->>Local: local.model.variant.cycle()
    Local->>Local: Cycles to next variant
    Local-->>TUI: Triggers re-render
    TUI->>User: Updates displayed variant
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->