### PR TITLE
fix: remove XSS vulnerability (CVE-2026-22813) and duplicate variant tooltip

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -39,26 +39,25 @@ declare global {
 }
 
 const defaultServerUrl = iife(() => {
-  // 1. Query parameter (highest priority)
-  const param = new URLSearchParams(document.location.search).get("url")
-  if (param) return param
+  // NOTE: The ?url= query parameter was intentionally removed due to CVE-2026-22813 (GHSA-c83v-7274-4vgp)
+  // Allowing arbitrary server URLs via query params enables XSS attacks on localhost:4096
 
-  // 2. Configured server URL (from desktop settings)
+  // 1. Configured server URL (from desktop settings)
   if (window.__OPENCODE__?.serverUrl) return window.__OPENCODE__.serverUrl
 
-  // 3. Known production hosts -> localhost (same as upstream + shuv.ai)
+  // 2. Known production hosts -> localhost (same as upstream + shuv.ai)
   if (location.hostname.includes("opencode.ai") || location.hostname.includes("shuv.ai")) return "http://localhost:4096"
 
-  // 4. Desktop app (Tauri) with injected port
+  // 3. Desktop app (Tauri) with injected port
   if (window.__SHUVCODE__?.port) return `http://127.0.0.1:${window.__SHUVCODE__.port}`
   if (window.__OPENCODE__?.port) return `http://127.0.0.1:${window.__OPENCODE__.port}`
 
-  // 5. Dev mode -> same-origin so Vite proxy handles LAN access + CORS
+  // 4. Dev mode -> same-origin so Vite proxy handles LAN access + CORS
   if (import.meta.env.DEV) {
     return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
   }
 
-  // 6. Default -> same origin (production web command)
+  // 5. Default -> same origin (production web command)
   return window.location.origin
 })
 

--- a/packages/app/src/utils/hosted.ts
+++ b/packages/app/src/utils/hosted.ts
@@ -9,7 +9,11 @@ export function isHostedEnvironment(): boolean {
 
 /**
  * Checks if a ?url= query parameter was provided in the URL.
- * This indicates the user is trying to connect to a specific server.
+ *
+ * SECURITY WARNING: This function exists ONLY for display purposes (e.g., showing
+ * "Could not connect to X" in welcome-screen.tsx). The ?url= parameter must NEVER
+ * be used to determine actual server connections due to CVE-2026-22813 (XSS vulnerability).
+ * Server URL is determined exclusively by app.tsx defaultServerUrl logic.
  */
 export function hasUrlQueryParam(): boolean {
   if (typeof window === "undefined") return false
@@ -18,6 +22,11 @@ export function hasUrlQueryParam(): boolean {
 
 /**
  * Gets the ?url= query parameter value if present.
+ *
+ * SECURITY WARNING: This function exists ONLY for display purposes (e.g., showing
+ * error messages with the attempted URL). The returned value must NEVER be used
+ * for actual server connections due to CVE-2026-22813 (XSS vulnerability).
+ * Server URL is determined exclusively by app.tsx defaultServerUrl logic.
  */
 export function getUrlQueryParam(): string | null {
   if (typeof window === "undefined") return null

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1122,11 +1122,6 @@ export function Prompt(props: PromptProps) {
                   <text fg={theme.text}>
                     {keybind.print("command_list")} <span style={{ fg: theme.textMuted }}>commands</span>
                   </text>
-                  <Show when={hasVariants()}>
-                    <text fg={theme.text}>
-                      {keybind.print("variant_cycle")} <span style={{ fg: theme.textMuted }}>cycle variants</span>
-                    </text>
-                  </Show>
                 </Match>
                 <Match when={store.mode === "shell"}>
                   <text fg={theme.text}>

--- a/script/sync/fork-features.json
+++ b/script/sync/fork-features.json
@@ -120,6 +120,19 @@
         "Session migration for linked worktrees"
       ],
       "note": "Upstream uses Project.sandboxes array to track worktrees. Main worktree is always Project.worktree."
+    },
+    {
+      "pr": "CVE-2026-22813",
+      "title": "Query parameter server URL override",
+      "author": "fork",
+      "removedDate": "2026-01-12",
+      "reason": "Critical XSS vulnerability (GHSA-c83v-7274-4vgp, CVE-2026-22813) - malicious websites could execute commands via ?url= parameter. Upstream fixed in v1.1.10 by removing this feature.",
+      "filesModified": ["packages/app/src/app.tsx"],
+      "codeRemoved": [
+        "const param = new URLSearchParams(document.location.search).get('url')",
+        "if (param) return param"
+      ],
+      "note": "The ?url= query parameter allowed arbitrary server URL override, enabling XSS on localhost:4096. Attackers could inject malicious server URLs that return XSS payloads, then use /pty/ API to execute arbitrary commands."
     }
   ],
   "apiDependencies": [


### PR DESCRIPTION
## Summary

- **Security Fix**: Remove `?url=` query parameter from `app.tsx` to fix CVE-2026-22813 (GHSA-c83v-7274-4vgp)
- **UI Fix**: Remove duplicate variant cycle tooltip from TUI prompt (upstream now has their own version)
- **Documentation**: Update `fork-features.json` to document the security fix

## Security Details

**CVE-2026-22813** - Critical XSS vulnerability (CVSS 9.4)

The `?url=` query parameter allowed malicious websites to:
1. Trick users into opening `localhost:4096?url=http://attacker.example`
2. Load attacker-controlled content into the OpenCode web UI
3. Execute arbitrary commands via the `/pty/` API endpoints

Upstream fixed this in v1.1.10, but our fork had re-added the feature. This PR removes it.

## Testing

- TypeScript checks pass
- Tests pass (724 pass, 0 fail)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR addresses a critical XSS vulnerability (CVE-2026-22813) and removes a duplicate UI element.

## Security Fix Analysis

The PR removes the `?url=` query parameter from the `defaultServerUrl` function in `app.tsx`, which previously allowed attackers to inject arbitrary server URLs. The attack vector was:
1. Attacker sends link: `localhost:4096?url=http://malicious.example`
2. ShuvCode UI would connect to the attacker's server
3. Attacker serves XSS payload that executes commands via `/pty/` API

**What was fixed:**
- Removed query parameter reading from `defaultServerUrl` in `app.tsx` (lines 42-44)
- Added clear security comment explaining why this was removed
- Updated priority order for server URL resolution
- Documented the removal in `fork-features.json`

**Critical Issue Found:**
The fix is **incomplete**. The `?url=` query parameter infrastructure remains accessible through:
- `packages/app/src/utils/hosted.ts` functions (`getUrlQueryParam()`, `hasUrlQueryParam()`)
- `packages/app/src/components/welcome-screen.tsx` still calls and displays this value
- Tests in `packages/app/test/hosted.test.ts` validate this functionality

While the display usage is likely safe (SolidJS escapes text), this creates confusion and leaves the door open for future re-introduction of the vulnerability.

## UI Fix

Successfully removes the duplicate "cycle variants" tooltip from the TUI prompt component. The conditional tooltip wrapped in `<Show when={hasVariants()}>` is removed, while the main variants tooltip remains.

## Documentation

The `fork-features.json` properly documents this security fix with comprehensive details about the vulnerability, attack vector, and removal rationale.

### Confidence Score: 3/5

- This PR is partially safe to merge with one critical security gap that needs addressing
- The score reflects that while the main XSS vulnerability is fixed in app.tsx (preventing the actual exploit), the incomplete cleanup leaves security-sensitive code in place. The ?url= parameter reading functions in hosted.ts and their usage in welcome-screen.tsx create technical debt and confusion about the security posture. The UI fix is solid (5/5), but the security fix deserves a 3/5 due to incomplete remediation. Recommend either completing the removal of all ?url= infrastructure or adding explicit documentation about safe display-only usage.
- packages/app/src/app.tsx requires follow-up to remove related ?url= parameter infrastructure (hosted.ts functions and welcome-screen.tsx usage)

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/app/src/app.tsx | 3/5 | Removes ?url= query parameter from defaultServerUrl to fix XSS vulnerability CVE-2026-22813, adds security comment explaining the removal |
| packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx | 5/5 | Removes duplicate conditional variant cycle tooltip, keeping the main variants tooltip (upstream now provides their own) |
| script/sync/fork-features.json | 5/5 | Documents the CVE-2026-22813 security fix in removedFeatures, explains the XSS attack vector and why the feature was removed |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Attacker
    participant User
    participant Browser
    participant ShuvCode UI
    participant LocalServer
    
    Note over Attacker,LocalServer: BEFORE FIX (CVE-2026-22813)
    Attacker->>User: Send link: localhost:4096?url=http://evil.com
    User->>Browser: Click link
    Browser->>ShuvCode UI: Load with ?url=http://evil.com
    ShuvCode UI->>ShuvCode UI: Read URLSearchParams("url")
    ShuvCode UI->>ShuvCode UI: Set serverUrl = http://evil.com
    ShuvCode UI->>Attacker: Connect to http://evil.com
    Attacker->>ShuvCode UI: Return malicious XSS payload
    ShuvCode UI->>LocalServer: Execute commands via /pty/ API
    
    Note over Attacker,LocalServer: AFTER FIX
    Attacker->>User: Send link: localhost:4096?url=http://evil.com
    User->>Browser: Click link
    Browser->>ShuvCode UI: Load with ?url=http://evil.com
    ShuvCode UI->>ShuvCode UI: SKIP query param (removed)
    ShuvCode UI->>ShuvCode UI: Use safe defaults only
    ShuvCode UI->>LocalServer: Connect to localhost:4096
    Note over ShuvCode UI,LocalServer: Safe connection - no XSS possible
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->