### PR TITLE
fix: respect OPENCODE_DISABLE_MODELS_FETCH flag in ModelsDev.get()

### DIFF
--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -76,6 +76,7 @@ export namespace ModelsDev {
   export type Provider = z.infer<typeof Provider>
 
   export async function get() {
+    if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
     refresh()
     const file = Bun.file(filepath)
     const result = await file.json().catch(() => {})


### PR DESCRIPTION
### What does this PR do?

Fixes OPENCODE_DISABLE_MODELS_FETCH to actually work.
Previously the flag only prevented refresh() from fetching - but get() would still read cached data or fall back to build-time embedded macro data. So even with the flag set and cache deleted, users still saw models.dev models merged in.
Now get() returns {} immediately when the flag is set, so only locally configured providers/models appear.
export async function get() {
  if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
  // ...
}
Related: #4959

### How did you verify your code works?

Ran OPENCODE_DISABLE_MODELS_FETCH=true bun dev models and compared output to ~/.config/opencode/opencode.json:
- Output showed exactly 64 models across 7 providers (antigravity, gemini-cli, nano-gpt, nvidia-nim, chutes, longcat, mistral)
- Every model in output matched a model explicitly defined in local config
- No models.dev merged models appeared

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>


This PR fixes `OPENCODE_DISABLE_MODELS_FETCH` to fully prevent models.dev data from being used. Previously, the flag only prevented `refresh()` from fetching new data, but `get()` would still read cached data or fall back to build-time embedded data. Now `get()` returns an empty object immediately when the flag is set.

**Key changes:**
- Added early return `if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}` at the start of `ModelsDev.get()` on line 79
- When enabled, only locally configured providers/models appear (no models.dev providers merged in)
- PR author verified output shows exactly 64 models from local config with no models.dev models

**Testing:** Manual verification with `OPENCODE_DISABLE_MODELS_FETCH=true bun dev models` confirmed correct behavior.


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The change is a simple, well-targeted fix that adds a single early return guard. The logic is straightforward, matches the existing pattern in `refresh()`, and has been manually tested. The empty object return is safe since the consuming code already handles empty provider records (as seen in provider.ts:608-609 where it uses `mapValues` which works fine with empty objects).
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/opencode/src/provider/models.ts | Added early return in `get()` to respect `OPENCODE_DISABLE_MODELS_FETCH` flag |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Provider
    participant ModelsDev
    participant Flag
    participant Cache
    participant Macro

    Note over User,Macro: Before this PR (Flag set but still returns data)
    User->>Provider: Get providers
    Provider->>ModelsDev: get()
    ModelsDev->>Flag: Check OPENCODE_DISABLE_MODELS_FETCH
    Flag-->>ModelsDev: true
    Note over ModelsDev: Flag is set, but get() continues...
    ModelsDev->>Cache: Read cached models.json
    alt Cache exists
        Cache-->>ModelsDev: Return cached data
    else No cache
        ModelsDev->>Macro: Load embedded data
        Macro-->>ModelsDev: Return build-time data
    end
    ModelsDev-->>Provider: Return models.dev providers
    Provider-->>User: Returns local + models.dev merged

    Note over User,Macro: After this PR (Flag properly respected)
    User->>Provider: Get providers
    Provider->>ModelsDev: get()
    ModelsDev->>Flag: Check OPENCODE_DISABLE_MODELS_FETCH
    Flag-->>ModelsDev: true
    ModelsDev-->>Provider: return {} (early exit)
    Provider-->>User: Returns only local providers
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->