### PR TITLE
feat(tui): show subagents in sidebar based on subagent_type property

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -61,7 +61,7 @@ export function Sidebar(props: { sessionID: string; width: number; overlay?: boo
     const parts: ToolPart[] = []
     for (const message of messages()) {
       for (const part of sync.data.part[message.id] ?? []) {
-        if (part.type === "tool" && part.tool === "task") parts.push(part)
+        if (part.type === "tool" && part.state.input?.subagent_type) parts.push(part)
       }
     }
     return parts
@@ -139,7 +139,7 @@ export function Sidebar(props: { sessionID: string; width: number; overlay?: boo
                 <text fg={theme.textMuted}>{session()?.share?.url}</text>
               </Show>
             </box>
-{/* Context Section */}
+            {/* Context Section */}
             <box>
               <box flexDirection="row" gap={1} onMouseDown={() => setExpandedWithPersist("context", !expanded.context)}>
                 <text fg={theme.text}>{expanded.context ? "▼" : "▶"}</text>


### PR DESCRIPTION
**Description**
This PR updates the TUI sidebar's Subagents section to be more agnostic about how subagents are invoked.

Previously, the sidebar logic relied on specific tool names or structures found in the default OpenCode implementation. This update generalizes the detection logic to check for the presence of the `subagent_type` property in the tool input.

**Why this is needed**
Plugins like `oh-my-opencode` use their own orchestration tools (e.g., delegate_task) rather than the default `task` tool. However, they still adhere to the convention of passing a subagent_type to identify the agent being called.

By keying off this property, we ensure that any future plugin can now trigger subagent UI elements simply by including subagent_type in their tool arguments.

**Changes**
One liner change to `sidebar.tsx`

### How did you verify your code works?

Default OpenCode Build agent with this code integrated.

<img width="650" alt="2026-01-18_17h42_29" src="https://github.com/user-attachments/assets/bb667770-983a-466e-9fbe-9dc6fa462a48" />

**`oh-mh-opencode` without this change DOES NOT SHOW agents.** 
Here's what it shows with this change.

<img width="650" alt="2026-01-18_17h42_59" src="https://github.com/user-attachments/assets/0207f3c5-da27-46b6-98c0-a706a7b4a243" />

closes #306

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>


Generalizes TUI sidebar subagent detection to support plugin tools beyond the default `task` tool.

**Key Changes:**
- Changed filter from `part.tool === "task"` to `part.state.input?.subagent_type` check on `sidebar.tsx:64`
- Enables plugins like `oh-my-opencode` using custom orchestration tools (e.g., `delegate_task`) to display subagents in the sidebar
- Maintains backward compatibility since the default `task` tool includes `subagent_type` in its input parameters
- Fixed comment indentation as minor cleanup


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The change is a simple, well-scoped refactor that improves extensibility. The detection logic now checks for the presence of `subagent_type` property rather than a specific tool name, which is more flexible and maintains backward compatibility. All tool states (pending, running, completed, error) include the `input` field with the same structure, so the optional chaining `?.` safely handles any edge cases.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx | Generalized subagent detection from tool name to `subagent_type` property check; fixed comment indentation |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Plugin as Plugin (oh-my-opencode)
    participant TUI as TUI Sidebar
    participant Tool as Tool Invocation
    participant Filter as taskToolParts Filter
    
    Note over Plugin,Filter: Before PR: Only tools with name "task" are detected
    
    Plugin->>Tool: Invoke delegate_task<br/>(custom tool name)
    Tool->>Tool: Include subagent_type<br/>in input parameters
    Tool->>TUI: Create ToolPart with<br/>state.input.subagent_type
    TUI->>Filter: Filter parts where<br/>part.tool === "task"
    Filter-->>TUI: No match (delegate_task ≠ task)
    Note over TUI: Subagent not shown in sidebar
    
    Note over Plugin,Filter: After PR: Any tool with subagent_type is detected
    
    Plugin->>Tool: Invoke delegate_task<br/>(custom tool name)
    Tool->>Tool: Include subagent_type<br/>in input parameters
    Tool->>TUI: Create ToolPart with<br/>state.input.subagent_type
    TUI->>Filter: Filter parts where<br/>part.state.input?.subagent_type exists
    Filter-->>TUI: Match found (has subagent_type)
    TUI->>TUI: Display subagent in sidebar
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->