### PR TITLE
fix(test): honor cached models when fetch disabled

### DIFF
--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -77,8 +77,9 @@ export namespace ModelsDev {
   export type Provider = z.infer<typeof Provider>
 
   export async function get() {
-    if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
-    refresh()
+    if (!Flag.OPENCODE_DISABLE_MODELS_FETCH) {
+      refresh()
+    }
     const file = Bun.file(filepath)
     const result = await file.json().catch(() => {})
     if (result) return result as Record<string, Provider>
@@ -87,6 +88,9 @@ export namespace ModelsDev {
     if (typeof data === "function") {
       const json = await data()
       return JSON.parse(json) as Record<string, Provider>
+    }
+    if (Flag.OPENCODE_DISABLE_MODELS_FETCH) {
+      throw new Error("Models fetch disabled and no cached data available")
     }
     // Direct fetch fallback when macro is unavailable
     const response = await fetch("https://models.dev/api.json", {

--- a/packages/opencode/test/preload.ts
+++ b/packages/opencode/test/preload.ts
@@ -30,7 +30,7 @@ process.env["OPENCODE_DISABLE_DEFAULT_PLUGINS"] = "true"
 // Also write the cache version file to prevent global/index.ts from clearing the cache
 const cacheDir = path.join(dir, "cache", "opencode")
 await fs.mkdir(cacheDir, { recursive: true })
-await fs.writeFile(path.join(cacheDir, "version"), "14")
+await fs.writeFile(path.join(cacheDir, "version"), "18")
 const response = await fetch("https://models.dev/api.json")
 if (response.ok) {
   await fs.writeFile(path.join(cacheDir, "models.json"), await response.text())


### PR DESCRIPTION
## Summary

Fix provider tests by allowing cached models.json to load even when OPENCODE_DISABLE_MODELS_FETCH is set.

## Changes

### Fixes
- Skip models.dev refresh when fetch is disabled, but still read cached models.json
- Align test preload cache version with current cache version to avoid cache purges

## Breaking Changes

None

## Testing

- bun test (packages/opencode)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>


Fixed provider tests by allowing cached `models.json` to be read when `OPENCODE_DISABLE_MODELS_FETCH` is enabled.

**Key Changes:**
- Inverted condition in `ModelsDev.get()` to only skip `refresh()` when fetch is disabled, but continue attempting to read cached data
- Added explicit error when fetch is disabled and no cached data is available
- Updated test cache version from 14 to 18 to match current `CACHE_VERSION` and prevent cache purges during test initialization

The fix correctly separates refresh behavior (network fetch) from cache reading, ensuring tests can use pre-populated cache data without triggering network requests.


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- Safe to merge - clean logic fix with proper error handling
- The changes are minimal, focused, and correct the test failure issue. The logic properly separates refresh (network) from cache reading, adds explicit error handling, and aligns test cache version with production
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/opencode/src/provider/models.ts | Fixed logic to allow cached models.json to load when fetch is disabled, with proper error handling |
| packages/opencode/test/preload.ts | Updated cache version from 14 to 18 to match current cache version and prevent cache purges |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test as Test Suite
    participant Preload as preload.ts
    participant ModelsDev as ModelsDev.get()
    participant Cache as models.json Cache
    participant API as models.dev API

    Note over Test,API: Test Initialization
    Preload->>Cache: Write cache version "18"
    Preload->>API: Fetch models.json
    API-->>Preload: Return models data
    Preload->>Cache: Write models.json
    Preload->>Preload: Set OPENCODE_DISABLE_MODELS_FETCH=true

    Note over Test,API: Test Execution (Fetch Disabled)
    Test->>ModelsDev: Call get()
    ModelsDev->>ModelsDev: Check OPENCODE_DISABLE_MODELS_FETCH
    Note over ModelsDev: Flag is true, skip refresh()
    ModelsDev->>Cache: Read models.json
    Cache-->>ModelsDev: Return cached data
    ModelsDev-->>Test: Return models
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->