### PR TITLE
fix(sync): improve session synchronization handling and error recovery to fix duplicates showing in subagents sidebar.

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -423,26 +423,33 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         },
         async sync(sessionID: string) {
           if (fullSyncedSessions.has(sessionID)) return
-          const [session, messages, todo, diff] = await Promise.all([
-            sdk.client.session.get({ sessionID }, { throwOnError: true }),
-            sdk.client.session.messages({ sessionID, limit: 100 }),
-            sdk.client.session.todo({ sessionID }),
-            sdk.client.session.diff({ sessionID }),
-          ])
-          setStore(
-            produce((draft) => {
-              const match = Binary.search(draft.session, sessionID, (s) => s.id)
-              if (match.found) draft.session[match.index] = session.data!
-              if (!match.found) draft.session.splice(match.index, 0, session.data!)
-              draft.todo[sessionID] = todo.data ?? []
-              draft.message[sessionID] = messages.data!.map((x) => x.info)
-              for (const message of messages.data!) {
-                draft.part[message.info.id] = message.parts
-              }
-              draft.session_diff[sessionID] = diff.data ?? []
-            }),
-          )
+          // Mark as synced immediately to prevent duplicate concurrent syncs (race condition fix)
           fullSyncedSessions.add(sessionID)
+          try {
+            const [session, messages, todo, diff] = await Promise.all([
+              sdk.client.session.get({ sessionID }, { throwOnError: true }),
+              sdk.client.session.messages({ sessionID, limit: 100 }),
+              sdk.client.session.todo({ sessionID }),
+              sdk.client.session.diff({ sessionID }),
+            ])
+            setStore(
+              produce((draft) => {
+                const match = Binary.search(draft.session, sessionID, (s) => s.id)
+                if (match.found) draft.session[match.index] = session.data!
+                if (!match.found) draft.session.splice(match.index, 0, session.data!)
+                draft.todo[sessionID] = todo.data ?? []
+                draft.message[sessionID] = messages.data!.map((x) => x.info)
+                for (const message of messages.data!) {
+                  draft.part[message.info.id] = message.parts
+                }
+                draft.session_diff[sessionID] = diff.data ?? []
+              }),
+            )
+          } catch (e) {
+            // Remove from set on failure so retry is possible
+            fullSyncedSessions.delete(sessionID)
+            throw e
+          }
         },
       },
       bootstrap,

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -57,16 +57,20 @@ export function Sidebar(props: { sessionID: string; width: number; overlay?: boo
       .sort(([a], [b]) => a.localeCompare(b))
   )
 
+  // Collect all Task tool parts with subagent_type, deduplicated by part ID
   const taskToolParts = createMemo(() => {
-    const parts: ToolPart[] = []
+    const partsMap = new Map<string, ToolPart>()
     for (const message of messages()) {
       for (const part of sync.data.part[message.id] ?? []) {
-        if (part.type === "tool" && part.state.input?.subagent_type) parts.push(part)
+        if (part.type === "tool" && part.state.input?.subagent_type) {
+          partsMap.set(part.id, part)
+        }
       }
     }
-    return parts
+    return Array.from(partsMap.values())
   })
 
+  // Group parts by agent type for organized display
   const subagentGroups = createMemo(() => {
     const groups = new Map<string, ToolPart[]>()
     for (const part of taskToolParts()) {
@@ -186,10 +190,18 @@ export function Sidebar(props: { sessionID: string; width: number; overlay?: boo
                           </box>
                           <For each={parts}>
                             {(part) => {
-                              const isActive = () => part.state.status === "running" || part.state.status === "pending"
-                              const isError = () => part.state.status === "error"
+                              const status = () => part.state.status
+                              const isActive = () => status() === "running" || status() === "pending"
                               const input = part.state.input as Record<string, unknown>
                               const description = (input?.description as string) ?? ""
+
+                              // Memoize the indicator to avoid reactivity issues
+                              const indicator = createMemo(() => {
+                                if (status() === "running" || status() === "pending") {
+                                  return getSpinnerFrame()
+                                }
+                                return status() === "error" ? "✗" : "✓"
+                              })
 
                               // Get subagent session ID from metadata, not part.sessionID (which is the parent)
                               const metadata =
@@ -219,7 +231,7 @@ export function Sidebar(props: { sessionID: string; width: number; overlay?: boo
                                   }}
                                 >
                                   <text flexShrink={0} fg={isActive() ? theme.success : theme.textMuted}>
-                                    {isActive() ? getSpinnerFrame() : isError() ? "✗" : "✓"}
+                                    {indicator()}
                                   </text>
                                   <text fg={isActive() ? theme.text : theme.textMuted} wrapMode="word">
                                     {description}

--- a/packages/opencode/src/cli/cmd/tui/util/spinners.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/spinners.ts
@@ -107,7 +107,7 @@ export const SPINNERS: Record<string, string[]> = {
 }
 
 /** Default spinner key */
-export const DEFAULT_SPINNER_KEY = "DUAL_DOTS_SPIN"
+export const DEFAULT_SPINNER_KEY = "DOTS"
 
 /** Default spinner interval in milliseconds */
 export const DEFAULT_SPINNER_INTERVAL_MS = 60


### PR DESCRIPTION
### What does this PR do?
  - Fix duplicate spinner indicators appearing side-by-side in the sidebar's Subagents section
  - Memoize the indicator computation to prevent SolidJS reactivity issues causing double-evaluation of getSpinnerFrame()
  - Deduplicate Task tool parts by part ID to prevent data-level duplicates
  - Fix race condition in session.sync() where concurrent calls could both pass the guard check

### How did you verify your code works?
  - Launch multiple subagents and verify each shows a single spinner while running
  - Verified completed subagents show a single ✓ checkmark
  - Verified failed subagents show a single ✗
  - Navigate between sessions rapidly and confirm no duplicate indicators appear.

Before:
<img width="265" height="409" alt="image" src="https://github.com/user-attachments/assets/18d43d67-ef43-4c32-ad58-02f4d660f8f6" />


After:
<img width="263" height="336" alt="image" src="https://github.com/user-attachments/assets/50993209-760c-41f4-a77e-cfc744c94543" />

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>


This PR fixes duplicate spinner indicators appearing in the sidebar's Subagents section through three coordinated changes:

- **Race condition fix in `sync.tsx:424-453`**: Moved the `fullSyncedSessions.add(sessionID)` call before the async API calls to prevent concurrent `sync()` calls from both passing the guard check. Added proper error recovery that removes the session from the set on failure to allow retries.

- **Data-level deduplication in `sidebar.tsx:61-71`**: Changed `taskToolParts` from collecting parts in an array to using a Map keyed by `part.id`, ensuring each Task tool part appears only once even if encountered multiple times during message iteration.

- **Reactivity fix in `sidebar.tsx:198-204`**: Wrapped the indicator logic in `createMemo()` to prevent SolidJS reactivity from causing `getSpinnerFrame()` to be evaluated multiple times per render, which was causing duplicate spinner frames to appear side-by-side.

- **UX improvement in `spinners.ts:110`**: Changed default spinner from `DUAL_DOTS_SPIN` (which displays two characters like "⠋⠋") to `DOTS` (single character like "⠋") for cleaner visual presentation.

The changes work together to eliminate duplicates at both the data layer (deduplication) and the rendering layer (memoization), while also preventing race conditions that could cause multiple sync operations.


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- All changes are well-targeted fixes that address specific bugs without introducing new complexity. The race condition fix follows proper error handling patterns with cleanup on failure. The deduplication logic correctly uses the part ID (which exists on the ToolPart type) as a unique key. The memoization prevents unnecessary re-evaluations in SolidJS reactive contexts. The spinner change is a cosmetic improvement with no functional impact.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/opencode/src/cli/cmd/tui/context/sync.tsx | Fixed race condition in session.sync() by marking session as synced before API calls, with proper error recovery |
| packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx | Deduplicated Task tool parts by ID and memoized spinner indicators to prevent duplicate display |
| packages/opencode/src/cli/cmd/tui/util/spinners.ts | Changed default spinner from DUAL_DOTS_SPIN to DOTS for cleaner single-character display |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Sidebar
    participant SyncContext
    participant API
    participant Store

    Note over User,Store: Session Synchronization Flow (with race condition fix)

    User->>Sidebar: Navigate to session
    Sidebar->>SyncContext: sync.session.sync(sessionID)
    
    alt Session not yet synced
        SyncContext->>SyncContext: Mark as synced (add to Set)
        Note over SyncContext: Race condition fix:<br/>Mark BEFORE API calls
        
        par Parallel API Calls
            SyncContext->>API: session.get()
            SyncContext->>API: session.messages()
            SyncContext->>API: session.todo()
            SyncContext->>API: session.diff()
        end
        
        API-->>SyncContext: All data returned
        
        SyncContext->>Store: Update store with session data
        Store->>Store: Deduplicate parts by ID
        Note over Store: Parts stored in map[messageID]
        
        SyncContext-->>Sidebar: Sync complete
        
    else Session already syncing/synced
        SyncContext-->>Sidebar: Early return (no-op)
    end
    
    Note over Sidebar: Render Subagents Section
    
    Sidebar->>Sidebar: taskToolParts (deduplicated by part.id)
    Note over Sidebar: Map deduplication prevents<br/>duplicate parts at data level
    
    Sidebar->>Sidebar: subagentGroups (group by type)
    
    loop For each subagent part
        Sidebar->>Sidebar: createMemo(indicator)
        Note over Sidebar: Memoization prevents<br/>double-evaluation of getSpinnerFrame()
        Sidebar->>User: Display single indicator per part
    end

    Note over SyncContext,Store: Error Recovery
    
    alt API call fails
        API-->>SyncContext: Error thrown
        SyncContext->>SyncContext: Remove from synced Set
        Note over SyncContext: Allows retry on failure
        SyncContext-->>Sidebar: Throw error
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->