### PR TITLE
fix(ci): use 127.0.0.1 for e2e server

### DIFF
--- a/packages/app/script/e2e-local.ts
+++ b/packages/app/script/e2e-local.ts
@@ -59,6 +59,7 @@ const extraArgs = (() => {
   return args
 })()
 
+const serverHost = process.env.OPENCODE_E2E_SERVER_HOST ?? "127.0.0.1"
 const [serverPort, webPort] = await Promise.all([freePort(), freePort()])
 
 const sandbox = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-e2e-"))
@@ -85,9 +86,9 @@ const serverEnv = {
 
 const runnerEnv = {
   ...process.env,
-  PLAYWRIGHT_SERVER_HOST: "localhost",
+  PLAYWRIGHT_SERVER_HOST: serverHost,
   PLAYWRIGHT_SERVER_PORT: String(serverPort),
-  VITE_OPENCODE_SERVER_HOST: "localhost",
+  VITE_OPENCODE_SERVER_HOST: serverHost,
   VITE_OPENCODE_SERVER_PORT: String(serverPort),
   PLAYWRIGHT_PORT: String(webPort),
 } satisfies Record<string, string>
@@ -116,7 +117,7 @@ const server = Bun.spawn(
     "--port",
     String(serverPort),
     "--hostname",
-    "127.0.0.1",
+    serverHost,
   ],
   {
     cwd: opencodeDir,
@@ -127,7 +128,7 @@ const server = Bun.spawn(
 )
 
 try {
-  await waitForHealth(`http://localhost:${serverPort}/global/health`, server)
+  await waitForHealth(`http://${serverHost}:${serverPort}/global/health`, server)
 
   const runner = Bun.spawn(["bun", "test:e2e", ...extraArgs], {
     cwd: appDir,


### PR DESCRIPTION
## Summary
- use a concrete loopback host in the local e2e runner to avoid Windows localhost resolution issues

## Testing
- bun test (packages/opencode) **failed**: ENOSPC in /tmp
- bun run test:e2e:local (packages/app) **failed**: ENOSPC in /tmp
- bun turbo typecheck (git hook)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>


Replaced `localhost` with `127.0.0.1` throughout the e2e local test runner to avoid Windows DNS resolution issues.

- Introduced `serverHost` variable with environment override support via `OPENCODE_E2E_SERVER_HOST`
- Updated all four occurrences: Playwright server host, Vite server host, server spawn hostname, and health check URL
- Maintains consistency across the entire e2e flow from server spawn to test runner configuration


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The change is a simple, focused fix that addresses a known Windows issue with localhost DNS resolution by using the explicit loopback IP address 127.0.0.1 instead. All usages are consistently updated, the implementation includes environment variable override capability for flexibility, and the change follows a clear pattern addressing a documented problem from the commit history.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/app/script/e2e-local.ts | Changed localhost to 127.0.0.1 to fix Windows resolution issues; clean implementation |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Script as e2e-local.ts
    participant Env as Environment
    participant Seed as seed-e2e.ts
    participant Server as OpenCode Server
    participant Health as Health Check
    participant Runner as E2E Test Runner
    
    Script->>Env: Read OPENCODE_E2E_SERVER_HOST
    Env-->>Script: Return 127.0.0.1 (default)
    Script->>Script: Acquire free ports
    Script->>Script: Create temp sandbox
    
    Script->>Seed: Spawn with serverEnv
    Seed-->>Script: Exit with code 0
    
    Script->>Server: Spawn on 127.0.0.1:serverPort
    Note over Server: Previously used localhost
    
    Script->>Health: Poll http://127.0.0.1:serverPort/global/health
    Health-->>Script: Health check OK
    
    Script->>Runner: Spawn with runnerEnv
    Note over Runner: PLAYWRIGHT_SERVER_HOST=127.0.0.1<br/>VITE_OPENCODE_SERVER_HOST=127.0.0.1
    Runner-->>Script: Exit with test results
    
    Script->>Server: Kill process
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->