### PR TITLE
fix(tui): restore attach command cwd auto-pass feature

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -21,21 +21,26 @@ export const AttachCommand = cmd({
         describe: "session id to continue",
       }),
   handler: async (args) => {
-    let directory = args.dir
     if (args.dir) {
       try {
         process.chdir(args.dir)
-        // Use resolved path for local directories to ensure file autocomplete,
-        // theme discovery, and exports use the correct directory
-        directory = process.cwd()
       } catch {
-        // If the directory doesn't exist locally (remote attach), pass it through.
+        // If the directory doesn't exist locally (remote attach), pass it through
+        // and skip defaulting to cwd
+        await tui({
+          url: args.url,
+          args: { sessionID: args.session },
+          directory: args.dir,
+        })
+        return
       }
     }
+    // Always pass client's cwd so attached sessions operate in the client's directory
+    // This ensures file autocomplete, theme discovery, and exports use the correct directory
     await tui({
       url: args.url,
       args: { sessionID: args.session },
-      directory,
+      directory: process.cwd(),
     })
   },
 })


### PR DESCRIPTION
## Summary

- Restores the fork-specific feature where `shuvcode attach` automatically passes the client's current working directory to the server
- This regressed during upstream merge of PR #8969 (commit 8ebb76647)
- Preserves upstream's improvement for remote `--dir` paths by early-returning when the directory doesn't exist locally

## Changes

When no `--dir` is provided, the attach command now passes `process.cwd()` as the directory, ensuring file autocomplete, theme discovery, and exports use the client's directory when attaching to a remote server.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR successfully restores a fork-specific feature where `shuvcode attach` automatically passes the client's current working directory to the server. The regression occurred during the upstream merge of PR #8969 (commit `8ebb76647`), which added support for remote `--dir` paths but inadvertently removed the automatic cwd passing when no `--dir` was specified.

**Key changes:**
- When no `--dir` flag is provided, the attach command now passes `process.cwd()` as the directory parameter
- Preserves upstream's improvement: when `--dir` is provided but doesn't exist locally, the path is passed through to the server (for remote attach scenarios)
- When `--dir` is provided and exists locally, changes to that directory and passes it via `process.cwd()`

**Impact:**
Ensures that file autocomplete, theme discovery, and exports operate in the client's directory context when attaching to remote servers, rather than using the server's launch directory.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The changes are well-contained to a single file with clear logic that handles all three scenarios correctly (no --dir, local --dir, remote --dir). The implementation preserves both the fork-specific feature and upstream's remote directory support. The code is straightforward with proper error handling and clear comments explaining the behavior.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/opencode/src/cli/cmd/tui/attach.ts | Restores fork-specific feature to pass client's cwd to server, with proper handling for remote directories |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as CLI Client
    participant Handler as AttachCommand Handler
    participant FS as File System
    participant TUI as TUI (app.tsx)
    participant SDK as SDKProvider
    participant Server as OpenCode Server

    CLI->>Handler: attach <url> [--dir <path>] [--session <id>]
    
    alt --dir provided
        Handler->>FS: process.chdir(args.dir)
        alt chdir succeeds (local directory)
            FS-->>Handler: success
            Note over Handler: Directory changed locally
            Handler->>FS: process.cwd()
            FS-->>Handler: current working directory
            Handler->>TUI: tui({ url, sessionID, directory: cwd })
        else chdir fails (remote directory)
            FS-->>Handler: throws error
            Note over Handler: Directory doesn't exist locally
            Handler->>TUI: tui({ url, sessionID, directory: args.dir })
            Handler->>Handler: return early
        end
    else no --dir provided
        Handler->>FS: process.cwd()
        FS-->>Handler: current working directory
        Handler->>TUI: tui({ url, sessionID, directory: cwd })
    end
    
    TUI->>SDK: Initialize SDK with directory
    SDK->>Server: API calls with x-opencode-directory header
    Note over Server: Uses client's directory for:<br/>- File autocomplete<br/>- Theme discovery<br/>- Exports
    Server-->>SDK: Responses
    SDK-->>TUI: Data
    TUI-->>CLI: Render interface
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->