### PR TITLE
Fix undo to skip ignored messages

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -523,7 +523,14 @@ export function Session() {
         const status = sync.data.session_status?.[route.sessionID]
         if (status?.type !== "idle") await sdk.client.session.abort({ sessionID: route.sessionID }).catch(() => {})
         const revert = session()?.revert?.messageID
-        const message = messages().findLast((x) => (!revert || x.id < revert) && x.role === "user")
+        const message = messages().findLast((x) => {
+          if (x.role !== "user") return false
+          if (revert && x.id >= revert) return false
+          // Skip messages where all text parts are ignored
+          const parts = sync.data.part[x.id]
+          const hasNonIgnoredText = parts?.some((p) => p.type === "text" && !p.ignored)
+          return hasNonIgnoredText
+        })
         if (!message) return
         sdk.client.session
           .revert({


### PR DESCRIPTION
## Summary
- When using undo/revert, skip messages where all text parts are marked as ignored, so the user reverts to the last meaningful message instead of an ignored one
- Fixes https://github.com/Opencode-DCP/opencode-dynamic-context-pruning/issues/191

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Enhanced the undo functionality to skip over messages where all text parts are marked as ignored by DCP, ensuring users revert to the last meaningful message.

- Modified the message filtering logic in the undo handler to check for non-ignored text parts
- Uses optional chaining and `some()` to verify at least one text part exists that isn't ignored
- Addresses issue #191 where undo would revert to ignored messages

Minor issues:
- Missing safety check when accessing `sync.data.part[message.id]` on line 543 (should use `?? []` fallback)
- Redo functionality may need similar ignored-message filtering for consistency
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with minor refinements needed
- The core logic correctly implements the feature to skip ignored messages during undo. Two minor issues identified: (1) missing null safety check on line 543 that could cause runtime error, and (2) redo functionality lacks similar ignored-message filtering for consistency. The implementation is targeted and focused on the stated issue.
- Line 543 needs a safety check (`?? []`), and consider updating redo at line 572 for consistency
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/opencode/src/cli/cmd/tui/routes/session/index.tsx | Added logic to skip messages with all ignored text parts during undo; minor safety concern with parts access |

</details>


</details>


<sub>Last reviewed commit: dc7314f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->