### PR TITLE
Add backslash+enter to insert newline in prompt

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -531,6 +531,17 @@ export function Prompt(props: PromptProps) {
     if (props.disabled) return
     if (autocomplete?.visible) return
     if (!store.prompt.input) return
+    const cursorOffset = input.cursorOffset
+    const before = cursorOffset > 0 ? input.plainText[cursorOffset - 1] : ""
+    if (sync.data.config.experimental?.backslash_newline !== false && before === "\\") {
+      input.cursorOffset = cursorOffset - 1
+      const start = input.logicalCursor
+      input.cursorOffset = cursorOffset
+      const end = input.logicalCursor
+      input.deleteRange(start.row, start.col, end.row, end.col)
+      input.insertText("\n")
+      return
+    }
     const trimmed = store.prompt.input.trim()
     if (trimmed === "exit" || trimmed === "quit" || trimmed === ":q") {
       exit()
@@ -902,6 +913,7 @@ export function Prompt(props: PromptProps) {
                     return
                   }
                 }
+
                 if (store.mode === "normal") autocomplete.onKeyDown(e)
                 if (!autocomplete.visible) {
                   if (

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1203,6 +1203,10 @@ export namespace Config {
       experimental: z
         .object({
           disable_paste_summary: z.boolean().optional(),
+          backslash_newline: z
+            .boolean()
+            .optional()
+            .describe("Enable backslash+enter to insert newline instead of submitting (default: true)"),
           batch_tool: z.boolean().optional().describe("Enable the batch tool"),
           openTelemetry: z
             .boolean()

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1390,6 +1390,10 @@ export type Config = {
     chatMaxRetries?: number
     disable_paste_summary?: boolean
     /**
+     * Enable backslash+enter to insert newline instead of submitting (default: true)
+     */
+    backslash_newline?: boolean
+    /**
      * Enable the batch tool
      */
     batch_tool?: boolean

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1937,6 +1937,10 @@ export type Config = {
   experimental?: {
     disable_paste_summary?: boolean
     /**
+     * Enable backslash+enter to insert newline instead of submitting (default: true)
+     */
+    backslash_newline?: boolean
+    /**
      * Enable the batch tool
      */
     batch_tool?: boolean


### PR DESCRIPTION
## Summary
- Adds support for typing `\` then pressing Enter to insert a newline instead of submitting the prompt
- Adds `experimental.backslash_newline` config option (defaults to `true`) to toggle this behavior
- Updates SDK type definitions to include the new config field

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a backslash+Enter escape sequence to insert a newline in the prompt input instead of submitting. Typing `\` then pressing Enter replaces the backslash with a newline character, following a common shell/terminal convention. The feature is enabled by default and can be toggled via `experimental.backslash_newline` in the config.

- Adds cursor-relative backslash detection in the `submit()` function that intercepts Enter presses when the character before the cursor is `\`
- Adds `backslash_newline` optional boolean to the experimental config schema with a default-true semantic (`!== false` check)
- Updates both v1 and v2 SDK type definitions to include the new config field
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge — it adds a small, well-scoped input handling feature with a config toggle and no impact on existing behavior when disabled.
- The implementation is clean and follows existing patterns in the codebase (cursor manipulation via cursorOffset/logicalCursor/deleteRange/insertText, config access via sync.data.config.experimental). The default-true opt-out pattern matches similar experimental flags. The only reason for not giving a 5 is that the feature lacks test coverage and there are minor edge cases (e.g., double-backslash `\\` is not handled specially, mid-text backslash before cursor triggers the behavior) that may or may not be intentional.
- Pay attention to `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx` — the core logic change lives here.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx | Adds backslash-newline handling in submit() — replaces trailing `\` before cursor with newline. Logic follows existing cursor manipulation patterns in the codebase. |
| packages/opencode/src/config/config.ts | Adds `backslash_newline` boolean option to experimental config schema, consistent with existing pattern for other experimental flags. |
| packages/sdk/js/src/gen/types.gen.ts | Adds `backslash_newline` optional boolean to SDK Config type with matching JSDoc, correctly placed within the experimental section. |
| packages/sdk/js/src/v2/gen/types.gen.ts | Adds `backslash_newline` optional boolean to v2 SDK Config type, mirrors v1 placement and documentation. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Prompt as Prompt Component
    participant Input as TextareaRenderable
    participant Config as Config Store

    User->>Prompt: Press Enter (submit keybind)
    Prompt->>Prompt: Check disabled / autocomplete / empty
    Prompt->>Input: Read cursorOffset & plainText[offset-1]
    alt Character before cursor is "\"
        Prompt->>Config: Check experimental.backslash_newline
        alt backslash_newline !== false (default: enabled)
            Prompt->>Input: Set cursorOffset to offset-1
            Input-->>Prompt: logicalCursor (start)
            Prompt->>Input: Set cursorOffset to offset
            Input-->>Prompt: logicalCursor (end)
            Prompt->>Input: deleteRange(start, end)
            Prompt->>Input: insertText("\n")
            Prompt-->>User: Newline inserted, no submit
        else backslash_newline === false
            Prompt->>Prompt: Continue to normal submit flow
        end
    else Character is not "\"
        Prompt->>Prompt: Continue to normal submit flow
    end
```
</details>


<sub>Last reviewed commit: 25fb016</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->